### PR TITLE
Implement admin CRUD and REST API for Res Pong

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- Use 4 spaces for indentation in PHP files.
+- Prefer single quotes for strings unless interpolation is needed.
+- Run `php -l` on modified PHP files before committing.

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -1,0 +1,108 @@
+(function($){
+    var columns = {
+        users: [
+            { data: 'id', title: 'ID' },
+            { data: 'email', title: 'Email' },
+            { data: 'username', title: 'Username' },
+            { data: 'first_name', title: 'First Name' },
+            { data: 'last_name', title: 'Last Name' }
+        ],
+        events: [
+            { data: 'id', title: 'ID' },
+            { data: 'name', title: 'Name' },
+            { data: 'start_datetime', title: 'Start' },
+            { data: 'end_datetime', title: 'End' },
+            { data: 'enabled', title: 'Enabled' }
+        ],
+        reservations: [
+            { data: 'id', title: 'ID' },
+            { data: 'user_id', title: 'User ID' },
+            { data: 'event_id', title: 'Event ID' },
+            { data: 'created_at', title: 'Created At' },
+            { data: 'presence_confirmed', title: 'Presence' }
+        ]
+    };
+
+    function initList(){
+        var table = $('#res-pong-list');
+        if(!table.length){ return; }
+        var entity = table.data('entity');
+        var dt = table.DataTable({
+            ajax: {
+                url: rp_admin.rest_url + entity,
+                dataSrc: '',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); }
+            },
+            columns: columns[entity]
+        });
+        table.on('click', 'tbody tr', function(){
+            var data = dt.row(this).data();
+            window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail&id=' + data.id;
+        });
+        $('#res-pong-add').on('click', function(e){
+            e.preventDefault();
+            window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail';
+        });
+    }
+
+    function populateForm(entity, id, form){
+        $.ajax({
+            url: rp_admin.rest_url + entity + '/' + id,
+            method: 'GET',
+            beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+            success: function(data){
+                for(var key in data){
+                    var field = form.find('[name='+key+']');
+                    if(field.attr('type') === 'checkbox'){
+                        field.prop('checked', parseInt(data[key]) === 1);
+                    } else {
+                        field.val(data[key]);
+                    }
+                }
+            }
+        });
+    }
+
+    function initDetail(){
+        var form = $('#res-pong-detail-form');
+        if(!form.length){ return; }
+        var entity = form.data('entity');
+        var id = form.data('id');
+        if(id){ populateForm(entity, id, form); }
+        form.on('submit', function(e){
+            e.preventDefault();
+            var data = {};
+            form.serializeArray().forEach(function(item){ data[item.name] = item.value; });
+            form.find('input[type=checkbox]').each(function(){ data[this.name] = $(this).is(':checked') ? 1 : 0; });
+            var method = id ? 'PUT' : 'POST';
+            var url = rp_admin.rest_url + entity + (id ? '/' + id : '');
+            $.ajax({
+                url: url,
+                method: method,
+                contentType: 'application/json',
+                data: JSON.stringify(data),
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(){
+                    window.location = rp_admin.admin_url + '?page=res-pong-' + entity;
+                }
+            });
+        });
+        $('#res-pong-delete').on('click', function(e){
+            e.preventDefault();
+            if(!id || !confirm('Delete item?')){ return; }
+            $.ajax({
+                url: rp_admin.rest_url + entity + '/' + id,
+                method: 'DELETE',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(){
+                    window.location = rp_admin.admin_url + '?page=res-pong-' + entity;
+                }
+            });
+        });
+    }
+
+    $(function(){
+        initList();
+        initDetail();
+    });
+})(jQuery);

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -1,0 +1,124 @@
+<?php
+
+class Res_Pong_Admin {
+    private $repository;
+
+    public function __construct($repository) {
+        $this->repository = $repository;
+        add_action('admin_menu', [ $this, 'register_menu' ]);
+        add_action('admin_enqueue_scripts', [ $this, 'enqueue_assets' ]);
+    }
+
+    public function register_menu() {
+        add_menu_page('Res Pong', 'Res Pong', 'manage_options', 'res-pong-users', [ $this, 'render_users_page' ], 'dashicons-table-row-after');
+        add_submenu_page('res-pong-users', 'Users', 'Users', 'manage_options', 'res-pong-users', [ $this, 'render_users_page' ]);
+        add_submenu_page('res-pong-users', 'Events', 'Events', 'manage_options', 'res-pong-events', [ $this, 'render_events_page' ]);
+        add_submenu_page('res-pong-users', 'Reservations', 'Reservations', 'manage_options', 'res-pong-reservations', [ $this, 'render_reservations_page' ]);
+        add_submenu_page(null, 'User Detail', 'User Detail', 'manage_options', 'res-pong-user-detail', [ $this, 'render_user_detail' ]);
+        add_submenu_page(null, 'Event Detail', 'Event Detail', 'manage_options', 'res-pong-event-detail', [ $this, 'render_event_detail' ]);
+        add_submenu_page(null, 'Reservation Detail', 'Reservation Detail', 'manage_options', 'res-pong-reservation-detail', [ $this, 'render_reservation_detail' ]);
+    }
+
+    public function enqueue_assets($hook) {
+        if (strpos($hook, 'res-pong') === false) {
+            return;
+        }
+        wp_enqueue_style('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css');
+        wp_enqueue_script('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js', [ 'jquery' ], null, true);
+        wp_enqueue_script('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/js/res-pong-admin.js', [ 'jquery', 'res-pong-datatables' ], RES_PONG_VERSION, true);
+        wp_localize_script('res-pong-admin', 'rp_admin', [
+            'rest_url'  => esc_url_raw(rest_url('res-pong/v1/')),
+            'nonce'     => wp_create_nonce('wp_rest'),
+            'admin_url' => admin_url('admin.php'),
+        ]);
+    }
+
+    // List pages
+    public function render_users_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('Users', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<table id="res-pong-list" class="display" data-entity="users"></table>';
+        echo '</div>';
+    }
+
+    public function render_events_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('Events', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<table id="res-pong-list" class="display" data-entity="events"></table>';
+        echo '</div>';
+    }
+
+    public function render_reservations_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__('Reservations', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<table id="res-pong-list" class="display" data-entity="reservations"></table>';
+        echo '</div>';
+    }
+
+    // Detail pages
+    public function render_user_detail() {
+        $id = isset($_GET['id']) ? sanitize_text_field($_GET['id']) : '';
+        $editing = !empty($id);
+        echo '<div class="wrap">';
+        echo '<h1>' . ($editing ? esc_html__('Edit User', 'res-pong') : esc_html__('Add User', 'res-pong')) . '</h1>';
+        echo '<form id="res-pong-detail-form" data-entity="users" data-id="' . esc_attr($id) . '">';
+        echo '<table class="form-table">';
+        echo '<tr><th><label for="id">ID</label></th><td><input name="id" id="id" type="text"></td></tr>';
+        echo '<tr><th><label for="email">Email</label></th><td><input name="email" id="email" type="email"></td></tr>';
+        echo '<tr><th><label for="username">Username</label></th><td><input name="username" id="username" type="text"></td></tr>';
+        echo '<tr><th><label for="first_name">First Name</label></th><td><input name="first_name" id="first_name" type="text"></td></tr>';
+        echo '<tr><th><label for="last_name">Last Name</label></th><td><input name="last_name" id="last_name" type="text"></td></tr>';
+        echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
+        echo '<tr><th><label for="password">Password</label></th><td><input name="password" id="password" type="password"></td></tr>';
+        echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"></td></tr>';
+        echo '</table>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
+        if ($editing) {
+            echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+        }
+        echo '</p></form></div>';
+    }
+
+    public function render_event_detail() {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        $editing = !empty($id);
+        echo '<div class="wrap">';
+        echo '<h1>' . ($editing ? esc_html__('Edit Event', 'res-pong') : esc_html__('Add Event', 'res-pong')) . '</h1>';
+        echo '<form id="res-pong-detail-form" data-entity="events" data-id="' . esc_attr($id) . '">';
+        echo '<table class="form-table">';
+        echo '<tr><th><label for="group_id">Group ID</label></th><td><input name="group_id" id="group_id" type="number"></td></tr>';
+        echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
+        echo '<tr><th><label for="name">Name</label></th><td><input name="name" id="name" type="text"></td></tr>';
+        echo '<tr><th><label for="note">Note</label></th><td><textarea name="note" id="note"></textarea></td></tr>';
+        echo '<tr><th><label for="start_datetime">Start</label></th><td><input name="start_datetime" id="start_datetime" type="text"></td></tr>';
+        echo '<tr><th><label for="end_datetime">End</label></th><td><input name="end_datetime" id="end_datetime" type="text"></td></tr>';
+        echo '<tr><th><label for="max_players">Max Players</label></th><td><input name="max_players" id="max_players" type="number"></td></tr>';
+        echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"></td></tr>';
+        echo '</table>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
+        if ($editing) {
+            echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+        }
+        echo '</p></form></div>';
+    }
+
+    public function render_reservation_detail() {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        $editing = !empty($id);
+        echo '<div class="wrap">';
+        echo '<h1>' . ($editing ? esc_html__('Edit Reservation', 'res-pong') : esc_html__('Add Reservation', 'res-pong')) . '</h1>';
+        echo '<form id="res-pong-detail-form" data-entity="reservations" data-id="' . esc_attr($id) . '">';
+        echo '<table class="form-table">';
+        echo '<tr><th><label for="user_id">User ID</label></th><td><input name="user_id" id="user_id" type="text"></td></tr>';
+        echo '<tr><th><label for="event_id">Event ID</label></th><td><input name="event_id" id="event_id" type="number"></td></tr>';
+        echo '<tr><th><label for="created_at">Created At</label></th><td><input name="created_at" id="created_at" type="text"></td></tr>';
+        echo '<tr><th><label for="presence_confirmed">Presence Confirmed</label></th><td><input name="presence_confirmed" id="presence_confirmed" type="checkbox" value="1"></td></tr>';
+        echo '</table>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
+        if ($editing) {
+            echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+        }
+        echo '</p></form></div>';
+    }
+}
+

--- a/includes/class-res-pong-repository.php
+++ b/includes/class-res-pong-repository.php
@@ -71,4 +71,76 @@ class Res_Pong_Repository {
         dbDelta($sql);
     }
 
+    // ------------------------
+    // RP_USER methods
+    // ------------------------
+
+    public function get_users() {
+        return $this->wpdb->get_results("SELECT * FROM {$this->table_user}", ARRAY_A);
+    }
+
+    public function get_user($id) {
+        return $this->wpdb->get_row($this->wpdb->prepare("SELECT * FROM {$this->table_user} WHERE id = %s", $id), ARRAY_A);
+    }
+
+    public function insert_user($data) {
+        return $this->wpdb->insert($this->table_user, $data);
+    }
+
+    public function update_user($id, $data) {
+        return $this->wpdb->update($this->table_user, $data, ['id' => $id]);
+    }
+
+    public function delete_user($id) {
+        return $this->wpdb->delete($this->table_user, ['id' => $id]);
+    }
+
+    // ------------------------
+    // RP_EVENT methods
+    // ------------------------
+
+    public function get_events() {
+        return $this->wpdb->get_results("SELECT * FROM {$this->table_event}", ARRAY_A);
+    }
+
+    public function get_event($id) {
+        return $this->wpdb->get_row($this->wpdb->prepare("SELECT * FROM {$this->table_event} WHERE id = %d", $id), ARRAY_A);
+    }
+
+    public function insert_event($data) {
+        return $this->wpdb->insert($this->table_event, $data);
+    }
+
+    public function update_event($id, $data) {
+        return $this->wpdb->update($this->table_event, $data, ['id' => $id]);
+    }
+
+    public function delete_event($id) {
+        return $this->wpdb->delete($this->table_event, ['id' => $id]);
+    }
+
+    // ------------------------
+    // RP_RESERVATION methods
+    // ------------------------
+
+    public function get_reservations() {
+        return $this->wpdb->get_results("SELECT * FROM {$this->table_reservation}", ARRAY_A);
+    }
+
+    public function get_reservation($id) {
+        return $this->wpdb->get_row($this->wpdb->prepare("SELECT * FROM {$this->table_reservation} WHERE id = %d", $id), ARRAY_A);
+    }
+
+    public function insert_reservation($data) {
+        return $this->wpdb->insert($this->table_reservation, $data);
+    }
+
+    public function update_reservation($id, $data) {
+        return $this->wpdb->update($this->table_reservation, $data, ['id' => $id]);
+    }
+
+    public function delete_reservation($id) {
+        return $this->wpdb->delete($this->table_reservation, ['id' => $id]);
+    }
+
 }

--- a/includes/class-res-pong-rest.php
+++ b/includes/class-res-pong-rest.php
@@ -1,0 +1,195 @@
+<?php
+
+class Res_Pong_Rest {
+    private $repository;
+
+    public function __construct($repository) {
+        $this->repository = $repository;
+        add_action('rest_api_init', [ $this, 'register_routes' ]);
+    }
+
+    public function register_routes() {
+        $namespace = 'res-pong/v1';
+
+        // Users
+        register_rest_route($namespace, '/users', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_get_users' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/users', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'rest_create_user' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/users/(?P<id>[\w-]+)', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_get_user' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/users/(?P<id>[\w-]+)', [
+            'methods'  => 'PUT',
+            'callback' => [ $this, 'rest_update_user' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/users/(?P<id>[\w-]+)', [
+            'methods'  => 'DELETE',
+            'callback' => [ $this, 'rest_delete_user' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+
+        // Events
+        register_rest_route($namespace, '/events', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_get_events' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/events', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'rest_create_event' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/events/(?P<id>\d+)', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_get_event' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/events/(?P<id>\d+)', [
+            'methods'  => 'PUT',
+            'callback' => [ $this, 'rest_update_event' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/events/(?P<id>\d+)', [
+            'methods'  => 'DELETE',
+            'callback' => [ $this, 'rest_delete_event' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+
+        // Reservations
+        register_rest_route($namespace, '/reservations', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_get_reservations' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/reservations', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'rest_create_reservation' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/reservations/(?P<id>\d+)', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_get_reservation' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/reservations/(?P<id>\d+)', [
+            'methods'  => 'PUT',
+            'callback' => [ $this, 'rest_update_reservation' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/reservations/(?P<id>\d+)', [
+            'methods'  => 'DELETE',
+            'callback' => [ $this, 'rest_delete_reservation' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+    }
+
+    // User handlers
+    public function rest_get_users() {
+        return rest_ensure_response($this->repository->get_users());
+    }
+
+    public function rest_get_user($request) {
+        $id = $request['id'];
+        $user = $this->repository->get_user($id);
+        if (!$user) {
+            return new WP_Error('not_found', 'User not found', [ 'status' => 404 ]);
+        }
+        return rest_ensure_response($user);
+    }
+
+    public function rest_create_user($request) {
+        $data = $request->get_json_params();
+        $this->repository->insert_user($data);
+        return new WP_REST_Response($data, 201);
+    }
+
+    public function rest_update_user($request) {
+        $id = $request['id'];
+        $data = $request->get_json_params();
+        $this->repository->update_user($id, $data);
+        return rest_ensure_response($this->repository->get_user($id));
+    }
+
+    public function rest_delete_user($request) {
+        $id = $request['id'];
+        $this->repository->delete_user($id);
+        return new WP_REST_Response(null, 204);
+    }
+
+    // Event handlers
+    public function rest_get_events() {
+        return rest_ensure_response($this->repository->get_events());
+    }
+
+    public function rest_get_event($request) {
+        $id = (int) $request['id'];
+        $event = $this->repository->get_event($id);
+        if (!$event) {
+            return new WP_Error('not_found', 'Event not found', [ 'status' => 404 ]);
+        }
+        return rest_ensure_response($event);
+    }
+
+    public function rest_create_event($request) {
+        $data = $request->get_json_params();
+        $this->repository->insert_event($data);
+        return new WP_REST_Response($data, 201);
+    }
+
+    public function rest_update_event($request) {
+        $id = (int) $request['id'];
+        $data = $request->get_json_params();
+        $this->repository->update_event($id, $data);
+        return rest_ensure_response($this->repository->get_event($id));
+    }
+
+    public function rest_delete_event($request) {
+        $id = (int) $request['id'];
+        $this->repository->delete_event($id);
+        return new WP_REST_Response(null, 204);
+    }
+
+    // Reservation handlers
+    public function rest_get_reservations() {
+        return rest_ensure_response($this->repository->get_reservations());
+    }
+
+    public function rest_get_reservation($request) {
+        $id = (int) $request['id'];
+        $reservation = $this->repository->get_reservation($id);
+        if (!$reservation) {
+            return new WP_Error('not_found', 'Reservation not found', [ 'status' => 404 ]);
+        }
+        return rest_ensure_response($reservation);
+    }
+
+    public function rest_create_reservation($request) {
+        $data = $request->get_json_params();
+        $this->repository->insert_reservation($data);
+        return new WP_REST_Response($data, 201);
+    }
+
+    public function rest_update_reservation($request) {
+        $id = (int) $request['id'];
+        $data = $request->get_json_params();
+        $this->repository->update_reservation($id, $data);
+        return rest_ensure_response($this->repository->get_reservation($id));
+    }
+
+    public function rest_delete_reservation($request) {
+        $id = (int) $request['id'];
+        $this->repository->delete_reservation($id);
+        return new WP_REST_Response(null, 204);
+    }
+}
+

--- a/includes/class-res-pong.php
+++ b/includes/class-res-pong.php
@@ -3,12 +3,20 @@
 defined('ABSPATH') || exit;
 
 require_once RES_PONG_PLUGIN_DIR . 'includes/class-res-pong-repository.php';
+require_once RES_PONG_PLUGIN_DIR . 'includes/class-res-pong-rest.php';
+require_once RES_PONG_PLUGIN_DIR . 'includes/class-res-pong-admin.php';
 
 class Res_Pong {
     private $repository;
+    private $rest;
+    private $admin;
 
     public function __construct() {
         $this->repository = new Res_Pong_Repository();
+        $this->rest = new Res_Pong_Rest($this->repository);
+        if (is_admin()) {
+            $this->admin = new Res_Pong_Admin($this->repository);
+        }
     }
 
     public function activate() {
@@ -18,5 +26,4 @@ class Res_Pong {
     public function deactivate() {
         error_log('deactivate res-pong');
     }
-
 }


### PR DESCRIPTION
## Summary
- add CRUD operations for users, events, and reservations in repository
- expose admin-only REST API endpoints for managing these entities
- add WordPress admin dashboard pages with DataTables and detail forms
- create shared admin JavaScript and AGENTS instructions

## Testing
- `php -l res-pong.php`
- `php -l includes/class-res-pong.php`
- `php -l includes/class-res-pong-repository.php`
- `php -l includes/class-res-pong-admin.php`
- `php -l includes/class-res-pong-rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d91d1cb6883288b54bfb134811e32