### PR TITLE
Add admin bulk actions and reservation joins

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -1,28 +1,97 @@
 (function($){
+    function renderCheckbox(data){
+        return '<input type="checkbox" class="rp-select" value="' + data.id + '">';
+    }
+    function renderBool(val){
+        return parseInt(val) === 1 ? '<span class="dashicons dashicons-yes"></span>' : '<span class="dashicons dashicons-no-alt"></span>';
+    }
+    function actionButtons(entity, data){
+        var edit = '<button class="button rp-edit" data-id="' + data.id + '">Modifica</button>';
+        var del = '<button class="button rp-delete" data-id="' + data.id + '">Cancella</button>';
+        var toggleLabel, state;
+        if(entity === 'reservations'){
+            state = parseInt(data.presence_confirmed);
+            toggleLabel = state ? 'Disabilita' : 'Abilita';
+        }else{
+            state = parseInt(data.enabled);
+            toggleLabel = state ? 'Disabilita' : 'Abilita';
+        }
+        var toggle = '<button class="button rp-toggle" data-id="' + data.id + '">' + toggleLabel + '</button>';
+        return edit + ' ' + del + ' ' + toggle;
+    }
     var columns = {
         users: [
+            { data: null, title: '', orderable: false, render: renderCheckbox },
             { data: 'id', title: 'ID' },
             { data: 'email', title: 'Email' },
             { data: 'username', title: 'Username' },
             { data: 'first_name', title: 'First Name' },
-            { data: 'last_name', title: 'Last Name' }
+            { data: 'last_name', title: 'Last Name' },
+            { data: 'category', title: 'Category' },
+            { data: 'timeout', title: 'Timeout' },
+            { data: 'enabled', title: 'Enabled', render: function(d){ return renderBool(d); } },
+            { data: null, title: 'Azioni', orderable: false, render: function(d){ return actionButtons('users', d); } }
         ],
         events: [
+            { data: null, title: '', orderable: false, render: renderCheckbox },
             { data: 'id', title: 'ID' },
+            { data: 'group_id', title: 'Group' },
+            { data: 'category', title: 'Category' },
             { data: 'name', title: 'Name' },
             { data: 'start_datetime', title: 'Start' },
             { data: 'end_datetime', title: 'End' },
-            { data: 'enabled', title: 'Enabled' }
+            { data: 'max_players', title: 'Max Players' },
+            { data: 'enabled', title: 'Enabled', render: function(d){ return renderBool(d); } },
+            { data: null, title: 'Status', render: function(d){ var now = new Date(); var start = new Date(d.start_datetime.replace(' ', 'T')); return now > start ? 'closed' : 'open'; } },
+            { data: null, title: 'Players', render: function(d){ return d.max_players ? d.players_count + '/' + d.max_players : ''; } },
+            { data: null, title: 'Azioni', orderable: false, render: function(d){ return actionButtons('events', d); } }
         ],
         reservations: [
+            { data: null, title: '', orderable: false, render: renderCheckbox },
             { data: 'id', title: 'ID' },
             { data: 'user_id', title: 'User ID' },
+            { data: 'username', title: 'Username' },
             { data: 'event_id', title: 'Event ID' },
+            { data: 'event_name', title: 'Event' },
             { data: 'created_at', title: 'Created At' },
-            { data: 'presence_confirmed', title: 'Presence' }
+            { data: 'presence_confirmed', title: 'Presence', render: function(d){ return renderBool(d); } },
+            { data: null, title: 'Azioni', orderable: false, render: function(d){ return actionButtons('reservations', d); } }
         ]
     };
-
+    function handleActions(table, entity){
+        table.on('click', '.rp-edit', function(){
+            var id = $(this).data('id');
+            window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail&id=' + id;
+        });
+        table.on('click', '.rp-delete', function(){
+            var id = $(this).data('id');
+            if(!confirm('Delete item?')){ return; }
+            $.ajax({
+                url: rp_admin.rest_url + entity + '/' + id,
+                method: 'DELETE',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(){ table.DataTable().ajax.reload(); }
+            });
+        });
+        table.on('click', '.rp-toggle', function(){
+            var id = $(this).data('id');
+            var row = table.DataTable().row($(this).closest('tr')).data();
+            var data = {};
+            if(entity === 'reservations'){
+                data.presence_confirmed = row.presence_confirmed == 1 ? 0 : 1;
+            }else{
+                data.enabled = row.enabled == 1 ? 0 : 1;
+            }
+            $.ajax({
+                url: rp_admin.rest_url + entity + '/' + id,
+                method: 'PUT',
+                contentType: 'application/json',
+                data: JSON.stringify(data),
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(){ table.DataTable().ajax.reload(); }
+            });
+        });
+    }
     function initList(){
         var table = $('#res-pong-list');
         if(!table.length){ return; }
@@ -35,16 +104,45 @@
             },
             columns: columns[entity]
         });
-        table.on('click', 'tbody tr', function(){
-            var data = dt.row(this).data();
-            window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail&id=' + data.id;
-        });
+        handleActions(table, entity);
         $('#res-pong-add').on('click', function(e){
             e.preventDefault();
             window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail';
         });
+        $('#rp-apply-bulk').on('click', function(){
+            var action = $('#rp-bulk-action').val();
+            var ids = table.find('.rp-select:checked').map(function(){ return this.value; }).get();
+            if(!action || ids.length === 0){ return; }
+            var progress = $('#rp-progress');
+            var bar = progress.find('progress');
+            var text = $('#rp-progress-text');
+            progress.show();
+            var i = 0;
+            function next(){
+                if(i >= ids.length){ progress.hide(); dt.ajax.reload(); return; }
+                var id = ids[i];
+                var url = rp_admin.rest_url + entity + '/' + id;
+                var method = action === 'delete' ? 'DELETE' : 'PUT';
+                var data = null;
+                if(action === 'enable'){ data = entity === 'reservations' ? { presence_confirmed:1 } : { enabled:1 }; }
+                if(action === 'disable'){ data = entity === 'reservations' ? { presence_confirmed:0 } : { enabled:0 }; }
+                $.ajax({
+                    url: url,
+                    method: method,
+                    contentType: 'application/json',
+                    data: data ? JSON.stringify(data) : null,
+                    beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                    complete: function(){
+                        i++;
+                        var perc = Math.round(i / ids.length * 100);
+                        bar.val(perc); text.text(perc + '%');
+                        next();
+                    }
+                });
+            }
+            next();
+        });
     }
-
     function populateForm(entity, id, form){
         $.ajax({
             url: rp_admin.rest_url + entity + '/' + id,
@@ -53,8 +151,11 @@
             success: function(data){
                 for(var key in data){
                     var field = form.find('[name='+key+']');
+                    if(!field.length){ continue; }
                     if(field.attr('type') === 'checkbox'){
                         field.prop('checked', parseInt(data[key]) === 1);
+                    } else if(field.attr('type') === 'datetime-local'){
+                        field.val(data[key].replace(' ', 'T'));
                     } else {
                         field.val(data[key]);
                     }
@@ -62,7 +163,6 @@
             }
         });
     }
-
     function initDetail(){
         var form = $('#res-pong-detail-form');
         if(!form.length){ return; }
@@ -74,6 +174,7 @@
             var data = {};
             form.serializeArray().forEach(function(item){ data[item.name] = item.value; });
             form.find('input[type=checkbox]').each(function(){ data[this.name] = $(this).is(':checked') ? 1 : 0; });
+            form.find('input[type=datetime-local]').each(function(){ data[this.name] = this.value.replace('T', ' '); });
             var method = id ? 'PUT' : 'POST';
             var url = rp_admin.rest_url + entity + (id ? '/' + id : '');
             $.ajax({
@@ -100,9 +201,69 @@
             });
         });
     }
-
+    function isEventOpen(data){
+        var now = new Date();
+        var start = new Date(data.event_start_datetime.replace(' ', 'T'));
+        return now <= start;
+    }
+    function initUserReservations(){
+        var table = $('#res-pong-user-reservations');
+        if(!table.length){ return; }
+        var user = table.data('user');
+        var dt = table.DataTable({
+            ajax: {
+                url: rp_admin.rest_url + 'reservations?user_id=' + user,
+                dataSrc: '',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); }
+            },
+            columns: [
+                { data: 'event_name', title: 'Evento' },
+                { data: 'created_at', title: 'Created At' },
+                { data: 'presence_confirmed', title: 'Presence', render: function(d){ return renderBool(d); } },
+                { data: null, title: 'Azioni', orderable: false, render: function(d){ return isEventOpen(d) ? '<button class="button rp-unsign" data-id="'+d.id+'">Disiscrivi</button>' : ''; } }
+            ]
+        });
+        table.on('click', '.rp-unsign', function(){
+            var id = $(this).data('id');
+            $.ajax({
+                url: rp_admin.rest_url + 'reservations/' + id,
+                method: 'DELETE',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(){ dt.ajax.reload(); }
+            });
+        });
+    }
+    function initEventReservations(){
+        var table = $('#res-pong-event-reservations');
+        if(!table.length){ return; }
+        var event = table.data('event');
+        var dt = table.DataTable({
+            ajax: {
+                url: rp_admin.rest_url + 'reservations?event_id=' + event,
+                dataSrc: '',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); }
+            },
+            columns: [
+                { data: 'user_id', title: 'User ID' },
+                { data: 'username', title: 'Username' },
+                { data: 'presence_confirmed', title: 'Presence', render: function(d){ return renderBool(d); } },
+                { data: null, title: 'Azioni', orderable: false, render: function(d){ return isEventOpen(d) ? '<button class="button rp-unsign" data-id="'+d.id+'">Disiscrivi</button>' : ''; } }
+            ]
+        });
+        table.on('click', '.rp-unsign', function(){
+            var id = $(this).data('id');
+            $.ajax({
+                url: rp_admin.rest_url + 'reservations/' + id,
+                method: 'DELETE',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(){ dt.ajax.reload(); }
+            });
+        });
+    }
     $(function(){
         initList();
         initDetail();
+        initUserReservations();
+        initEventReservations();
     });
 })(jQuery);

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -37,21 +37,27 @@ class Res_Pong_Admin {
     public function render_users_page() {
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('Users', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<div class="tablenav top"><div class="alignleft actions"><select id="rp-bulk-action"><option value="">' . esc_html__('Bulk Actions', 'res-pong') . '</option><option value="delete">' . esc_html__('Delete', 'res-pong') . '</option><option value="enable">' . esc_html__('Enable', 'res-pong') . '</option><option value="disable">' . esc_html__('Disable', 'res-pong') . '</option></select> <button class="button" id="rp-apply-bulk">' . esc_html__('Apply', 'res-pong') . '</button></div></div>';
         echo '<table id="res-pong-list" class="display" data-entity="users"></table>';
+        echo '<div id="rp-progress" style="display:none;"><progress max="100" value="0"></progress><span id="rp-progress-text">0%</span></div>';
         echo '</div>';
     }
 
     public function render_events_page() {
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('Events', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<div class="tablenav top"><div class="alignleft actions"><select id="rp-bulk-action"><option value="">' . esc_html__('Bulk Actions', 'res-pong') . '</option><option value="delete">' . esc_html__('Delete', 'res-pong') . '</option><option value="enable">' . esc_html__('Enable', 'res-pong') . '</option><option value="disable">' . esc_html__('Disable', 'res-pong') . '</option></select> <button class="button" id="rp-apply-bulk">' . esc_html__('Apply', 'res-pong') . '</button></div></div>';
         echo '<table id="res-pong-list" class="display" data-entity="events"></table>';
+        echo '<div id="rp-progress" style="display:none;"><progress max="100" value="0"></progress><span id="rp-progress-text">0%</span></div>';
         echo '</div>';
     }
 
     public function render_reservations_page() {
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__('Reservations', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<div class="tablenav top"><div class="alignleft actions"><select id="rp-bulk-action"><option value="">' . esc_html__('Bulk Actions', 'res-pong') . '</option><option value="delete">' . esc_html__('Delete', 'res-pong') . '</option><option value="enable">' . esc_html__('Enable', 'res-pong') . '</option><option value="disable">' . esc_html__('Disable', 'res-pong') . '</option></select> <button class="button" id="rp-apply-bulk">' . esc_html__('Apply', 'res-pong') . '</button></div></div>';
         echo '<table id="res-pong-list" class="display" data-entity="reservations"></table>';
+        echo '<div id="rp-progress" style="display:none;"><progress max="100" value="0"></progress><span id="rp-progress-text">0%</span></div>';
         echo '</div>';
     }
 
@@ -69,14 +75,25 @@ class Res_Pong_Admin {
         echo '<tr><th><label for="first_name">First Name</label></th><td><input name="first_name" id="first_name" type="text"></td></tr>';
         echo '<tr><th><label for="last_name">Last Name</label></th><td><input name="last_name" id="last_name" type="text"></td></tr>';
         echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
-        echo '<tr><th><label for="password">Password</label></th><td><input name="password" id="password" type="password"></td></tr>';
         echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"></td></tr>';
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
         if ($editing) {
             echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
         }
-        echo '</p></form></div>';
+        echo '</p></form>';
+        echo '<h2>' . esc_html__('Password Reset', 'res-pong') . '</h2>';
+        echo '<form id="res-pong-password-form" data-entity="users" data-id="' . esc_attr($id) . '">';
+        echo '<table class="form-table">';
+        echo '<tr><th><label for="new_password">New Password</label></th><td><input name="new_password" id="new_password" type="password"></td></tr>';
+        echo '<tr><th><label for="confirm_password">Confirm Password</label></th><td><input name="confirm_password" id="confirm_password" type="password"></td></tr>';
+        echo '</table>';
+        echo '<p class="submit"><button type="button" class="button" id="res-pong-invite">' . esc_html__('Invita', 'res-pong') . '</button> ';
+        echo '<button type="button" class="button" id="res-pong-reset-password">' . esc_html__('Reset Password', 'res-pong') . '</button></p>';
+        echo '</form>';
+        echo '<h2>' . esc_html__('User Reservations', 'res-pong') . '</h2>';
+        echo '<table id="res-pong-user-reservations" class="display" data-user="' . esc_attr($id) . '"></table>';
+        echo '</div>';
     }
 
     public function render_event_detail() {
@@ -90,8 +107,8 @@ class Res_Pong_Admin {
         echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
         echo '<tr><th><label for="name">Name</label></th><td><input name="name" id="name" type="text"></td></tr>';
         echo '<tr><th><label for="note">Note</label></th><td><textarea name="note" id="note"></textarea></td></tr>';
-        echo '<tr><th><label for="start_datetime">Start</label></th><td><input name="start_datetime" id="start_datetime" type="text"></td></tr>';
-        echo '<tr><th><label for="end_datetime">End</label></th><td><input name="end_datetime" id="end_datetime" type="text"></td></tr>';
+        echo '<tr><th><label for="start_datetime">Start</label></th><td><input name="start_datetime" id="start_datetime" type="datetime-local" step="1"></td></tr>';
+        echo '<tr><th><label for="end_datetime">End</label></th><td><input name="end_datetime" id="end_datetime" type="datetime-local" step="1"></td></tr>';
         echo '<tr><th><label for="max_players">Max Players</label></th><td><input name="max_players" id="max_players" type="number"></td></tr>';
         echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"></td></tr>';
         echo '</table>';
@@ -99,7 +116,10 @@ class Res_Pong_Admin {
         if ($editing) {
             echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
         }
-        echo '</p></form></div>';
+        echo '</p></form>';
+        echo '<h2>' . esc_html__('Event Reservations', 'res-pong') . '</h2>';
+        echo '<table id="res-pong-event-reservations" class="display" data-event="' . esc_attr($id) . '"></table>';
+        echo '</div>';
     }
 
     public function render_reservation_detail() {
@@ -111,7 +131,7 @@ class Res_Pong_Admin {
         echo '<table class="form-table">';
         echo '<tr><th><label for="user_id">User ID</label></th><td><input name="user_id" id="user_id" type="text"></td></tr>';
         echo '<tr><th><label for="event_id">Event ID</label></th><td><input name="event_id" id="event_id" type="number"></td></tr>';
-        echo '<tr><th><label for="created_at">Created At</label></th><td><input name="created_at" id="created_at" type="text"></td></tr>';
+        echo '<tr><th><label for="created_at">Created At</label></th><td><input name="created_at" id="created_at" type="datetime-local" step="1"></td></tr>';
         echo '<tr><th><label for="presence_confirmed">Presence Confirmed</label></th><td><input name="presence_confirmed" id="presence_confirmed" type="checkbox" value="1"></td></tr>';
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';

--- a/includes/class-res-pong-rest.php
+++ b/includes/class-res-pong-rest.php
@@ -160,8 +160,10 @@ class Res_Pong_Rest {
     }
 
     // Reservation handlers
-    public function rest_get_reservations() {
-        return rest_ensure_response($this->repository->get_reservations());
+    public function rest_get_reservations($request) {
+        $user_id = $request->get_param('user_id');
+        $event_id = $request->get_param('event_id');
+        return rest_ensure_response($this->repository->get_reservations($user_id, $event_id));
     }
 
     public function rest_get_reservation($request) {


### PR DESCRIPTION
## Summary
- add bulk actions with progress dialog and per-row action buttons for users, events, and reservations
- join reservations with users and events; expose filterable REST endpoint
- enhance detail pages with HTML5 dates, password reset form, and reservation tables

## Testing
- `php -l includes/class-res-pong-repository.php`
- `php -l includes/class-res-pong-rest.php`
- `php -l includes/class-res-pong-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689da128e2dc8328b6464e59cf303b7e