### PR TITLE
Stay on detail page after save with feedback

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -25,3 +25,15 @@
     text-align: center;
     border-radius: 4px;
 }
+
+.rp-button-danger {
+    background: #d63638;
+    border-color: #d63638;
+    color: #fff;
+}
+
+.rp-button-danger:hover {
+    background: #c72c2e;
+    border-color: #c72c2e;
+    color: #fff;
+}

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -22,9 +22,14 @@
     function hideOverlay(){
         $('#rp-progress-overlay').hide();
     }
+    function showNotice(type, text){
+        var wrap = $('.wrap').first();
+        wrap.find('.notice').remove();
+        $('<div class="notice notice-' + type + ' is-dismissible"><p>' + text + '</p></div>').prependTo(wrap);
+    }
     function actionButtons(entity, data){
         var edit = '<button class="button rp-edit" data-id="' + data.id + '">Modifica</button>';
-        var del = '<button class="button rp-delete" data-id="' + data.id + '">Cancella</button>';
+        var del = '<button class="button rp-delete rp-button-danger" data-id="' + data.id + '">Cancella</button>';
         var toggleLabel, state;
         if(entity === 'reservations'){
             state = parseInt(data.presence_confirmed);
@@ -231,8 +236,16 @@
                 data: JSON.stringify(data),
                 beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
                 complete: function(){ hideOverlay(); },
-                success: function(){
-                    window.location = rp_admin.admin_url + '?page=res-pong-' + entity;
+                success: function(resp){
+                    showNotice('success', 'Saved');
+                    if(!id && resp && resp.id){
+                        id = resp.id;
+                        form.attr('data-id', id);
+                        history.replaceState(null, '', rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail&id=' + id);
+                    }
+                },
+                error: function(){
+                    showNotice('error', 'Error saving');
                 }
             });
         });
@@ -247,6 +260,9 @@
                 complete: function(){ hideOverlay(); },
                 success: function(){
                     window.location = rp_admin.admin_url + '?page=res-pong-' + entity;
+                },
+                error: function(){
+                    showNotice('error', 'Error deleting');
                 }
             });
         });

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -84,8 +84,9 @@ class Res_Pong_Admin {
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
         if ($editing) {
-            echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
         }
+        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-users')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
         echo '</p></form>';
         echo '<h2>' . esc_html__('Password Reset', 'res-pong') . '</h2>';
         echo '<form id="res-pong-password-form" data-entity="users" data-id="' . esc_attr($id) . '">';
@@ -121,8 +122,9 @@ class Res_Pong_Admin {
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
         if ($editing) {
-            echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
         }
+        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-events')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
         echo '</p></form>';
         echo '<h2>' . esc_html__('Event Reservations', 'res-pong') . '</h2>';
         echo '<table id="res-pong-event-reservations" class="display" data-event="' . esc_attr($id) . '"></table>';
@@ -144,8 +146,9 @@ class Res_Pong_Admin {
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
         if ($editing) {
-            echo ' <button type="button" class="button button-secondary" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
         }
+        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-reservations')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
         echo '</p></form>';
         $this->render_progress_overlay();
         echo '</div>';


### PR DESCRIPTION
## Summary
- Keep users on detail pages after save and show success or error notices
- Add back-to-list buttons and redirect logic for deletions
- Highlight delete actions with a red danger style

## Testing
- `php -l includes/class-res-pong-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_689dc887249c8328b7902319368d193a