### PR TITLE
Show overlay during backend fetches

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -141,6 +141,15 @@
             },
             columns: columns[entity]
         });
+        dt.on('preXhr.dt', function(){
+            showOverlay(true);
+        });
+        dt.on('xhr.dt', function(){
+            hideOverlay();
+        });
+        dt.on('error.dt', function(){
+            hideOverlay();
+        });
         if(entity === 'events'){
             $('#rp-open-filter').on('change', function(){ dt.ajax.url(listUrl()).load(); });
         }else if(entity === 'reservations'){


### PR DESCRIPTION
## Summary
- show the indeterminate progress overlay whenever the list performs a backend fetch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc9d860e48328a1498a6b347db200