### PR TITLE
Display full user names and link list fields

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -54,8 +54,7 @@
             { data: 'id', title: 'ID', render: function(d){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-user-detail&id=' + d + '">' + d + '</a>'; } },
             { data: 'email', title: 'Email' },
             { data: 'username', title: 'Username' },
-            { data: 'first_name', title: 'First Name' },
-            { data: 'last_name', title: 'Last Name' },
+            { data: 'name', title: 'Name', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-user-detail&id=' + row.id + '">' + d + '</a>'; } },
             { data: 'category', title: 'Category' },
             { data: 'timeout', title: 'Timeout', render: function(d, type){ if(type === 'display'){ if(!d){ return ''; } var now = new Date(); var t = new Date(d.replace(' ', 'T')); return now < t ? d : ''; } return d; } },
             { data: 'timeout', title: 'In timeout', render: function(d, type){ if(!d){ return type === 'display' ? '' : 0; } var now = new Date(); var t = new Date(d.replace(' ', 'T')); var active = now < t; if(type === 'display'){ return active ? '<span class="dashicons dashicons-clock"></span>' : ''; } return active ? 1 : 0; } },
@@ -67,7 +66,7 @@
             { data: 'id', title: 'ID', render: function(d){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-event-detail&id=' + d + '">' + d + '</a>'; } },
             { data: 'group_id', title: 'Group' },
             { data: 'category', title: 'Category' },
-            { data: 'name', title: 'Name' },
+            { data: 'name', title: 'Name', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-event-detail&id=' + row.id + '">' + d + '</a>'; } },
             { data: 'start_datetime', title: 'Start' },
             { data: 'end_datetime', title: 'End' },
             { data: 'max_players', title: 'Max Players' },
@@ -403,6 +402,7 @@
             },
             columns: [
                 { data: 'event_name', title: 'Evento', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-event-detail&id=' + row.event_id + '">' + d + '</a>'; } },
+                { data: 'name', title: 'Name', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-user-detail&id=' + row.user_id + '">' + d + '</a>'; } },
                 { data: 'created_at', title: 'Created At' },
                 { data: 'presence_confirmed', title: 'Presence', render: function(d, type){ return type === 'display' ? renderBool(d) : d; } },
                 { data: null, title: 'Azioni', orderable: false, render: function(d){ return isEventOpen(d) ? '<button class="button rp-unsign" data-id="'+d.id+'">Disiscrivi</button>' : ''; } }
@@ -434,6 +434,7 @@
             },
             columns: [
                 { data: 'user_id', title: 'User ID', render: function(d){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-user-detail&id=' + d + '">' + d + '</a>'; } },
+                { data: 'name', title: 'Name', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-user-detail&id=' + row.user_id + '">' + d + '</a>'; } },
                 { data: 'username', title: 'Username' },
                 { data: 'presence_confirmed', title: 'Presence', render: function(d, type){ return type === 'display' ? renderBool(d) : d; } },
                 { data: null, title: 'Azioni', orderable: false, render: function(d){ return isEventOpen(d) ? '<button class="button rp-unsign" data-id="'+d.id+'">Disiscrivi</button>' : ''; } }

--- a/includes/class-res-pong-repository.php
+++ b/includes/class-res-pong-repository.php
@@ -76,11 +76,13 @@ class Res_Pong_Repository {
     // ------------------------
 
     public function get_users() {
-        return $this->wpdb->get_results("SELECT * FROM {$this->table_user}", ARRAY_A);
+        $sql = "SELECT *, CONCAT(last_name, ' ', first_name) AS name FROM {$this->table_user}";
+        return $this->wpdb->get_results($sql, ARRAY_A);
     }
 
     public function get_user($id) {
-        return $this->wpdb->get_row($this->wpdb->prepare("SELECT * FROM {$this->table_user} WHERE id = %s", $id), ARRAY_A);
+        $sql = "SELECT *, CONCAT(last_name, ' ', first_name) AS name FROM {$this->table_user} WHERE id = %s";
+        return $this->wpdb->get_row($this->wpdb->prepare($sql, $id), ARRAY_A);
     }
 
     public function insert_user($data) {
@@ -145,7 +147,7 @@ class Res_Pong_Repository {
             $params[] = current_time('mysql');
         }
         $where_sql = $where ? 'WHERE ' . implode(' AND ', $where) : '';
-        $sql = "SELECT r.*, u.username, e.name AS event_name, e.start_datetime AS event_start_datetime FROM {$this->table_reservation} r JOIN {$this->table_user} u ON r.user_id = u.id JOIN {$this->table_event} e ON r.event_id = e.id {$where_sql} ORDER BY r.created_at DESC";
+        $sql = "SELECT r.*, u.username, CONCAT(u.last_name, ' ', u.first_name) AS name, e.name AS event_name, e.start_datetime AS event_start_datetime FROM {$this->table_reservation} r JOIN {$this->table_user} u ON r.user_id = u.id JOIN {$this->table_event} e ON r.event_id = e.id {$where_sql} ORDER BY r.created_at DESC";
         if ($params) {
             $sql = $this->wpdb->prepare($sql, $params);
         }


### PR DESCRIPTION
## Summary
- show concatenated last and first names across repository queries
- add Name column in reservation and list tables with links to detail pages
- link Events and Users name fields to their edit pages

## Testing
- `php -l includes/class-res-pong-repository.php`

------
https://chatgpt.com/codex/tasks/task_e_689dcfb9edb88328ae749f2708f55a5b