### PR TITLE
Add presence toggle in event reservations

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -437,9 +437,17 @@
                 { data: 'name', title: 'Name', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-user-detail&id=' + row.user_id + '">' + d + '</a>'; } },
                 { data: 'username', title: 'Username' },
                 { data: 'presence_confirmed', title: 'Presence', render: function(d, type){ return type === 'display' ? renderBool(d) : d; } },
-                { data: null, title: 'Azioni', orderable: false, render: function(d){ return isEventOpen(d) ? '<button class="button rp-unsign" data-id="'+d.id+'">Disiscrivi</button>' : ''; } }
+                { data: null, title: 'Azioni', orderable: false, render: function(d){
+                    var toggleLabel = parseInt(d.presence_confirmed) ? 'Disabilita' : 'Abilita';
+                    var buttons = '<button class="button rp-toggle" data-id="' + d.id + '">' + toggleLabel + '</button>';
+                    if(isEventOpen(d)){
+                        buttons += ' <button class="button rp-unsign" data-id="' + d.id + '">Disiscrivi</button>';
+                    }
+                    return buttons;
+                } }
             ]
         });
+        handleActions(table, 'reservations');
         table.on('click', '.rp-unsign', function(){
             var id = $(this).data('id');
             if(!confirm('Delete item?')){ return; }


### PR DESCRIPTION
## Summary
- allow event reservations table to toggle presence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd14550ac8328b82668df49791080