### PR TITLE
Add CSV import/export for plugin tables

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -172,6 +172,33 @@
             e.preventDefault();
             window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail';
         });
+        $('#res-pong-export').on('click', function(e){
+            e.preventDefault();
+            window.location = restUrl(entity + '/export', '_wpnonce=' + rp_admin.nonce);
+        });
+        $('#res-pong-import').on('click', function(e){
+            e.preventDefault();
+            var input = $('<input type="file" accept=".csv" style="display:none">');
+            $('body').append(input);
+            input.on('change', function(){
+                var file = this.files[0];
+                if(!file){ input.remove(); return; }
+                var formData = new FormData();
+                formData.append('file', file);
+                showOverlay(true);
+                $.ajax({
+                    url: rp_admin.rest_url + entity + '/import',
+                    method: 'POST',
+                    data: formData,
+                    processData: false,
+                    contentType: false,
+                    beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                    complete: function(){ hideOverlay(); input.remove(); },
+                    success: function(){ dt.ajax.reload(); showNotice('success', 'Import completed'); },
+                    error: function(){ showNotice('error', 'Import failed'); }
+                });
+            }).trigger('click');
+        });
         $('#rp-apply-bulk').on('click', function(){
             var action = $('#rp-bulk-action').val();
             var ids = table.find('.rp-select:checked').map(function(){ return this.value; }).get();

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -41,7 +41,7 @@ class Res_Pong_Admin {
     // List pages
     public function render_users_page() {
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__('Users', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<h1>' . esc_html__('Users', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a> <a href="#" id="res-pong-import" class="page-title-action">' . esc_html__('Import CSV', 'res-pong') . '</a> <a href="#" id="res-pong-export" class="page-title-action">' . esc_html__('Export CSV', 'res-pong') . '</a></h1>';
         echo '<div class="tablenav top"><div class="alignleft actions"><select id="rp-bulk-action"><option value="">' . esc_html__('Bulk Actions', 'res-pong') . '</option><option value="delete">' . esc_html__('Delete', 'res-pong') . '</option><option value="enable">' . esc_html__('Enable', 'res-pong') . '</option><option value="disable">' . esc_html__('Disable', 'res-pong') . '</option><option value="timeout">' . esc_html__('Timeout', 'res-pong') . '</option></select> <button class="button" id="rp-apply-bulk">' . esc_html__('Apply', 'res-pong') . '</button></div></div>';
         echo '<table id="res-pong-list" class="display" data-entity="users"></table>';
         $this->render_progress_overlay();
@@ -50,7 +50,7 @@ class Res_Pong_Admin {
 
     public function render_events_page() {
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__('Events', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<h1>' . esc_html__('Events', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a> <a href="#" id="res-pong-import" class="page-title-action">' . esc_html__('Import CSV', 'res-pong') . '</a> <a href="#" id="res-pong-export" class="page-title-action">' . esc_html__('Export CSV', 'res-pong') . '</a></h1>';
         echo '<div class="tablenav top"><div class="alignleft actions"><select id="rp-bulk-action"><option value="">' . esc_html__('Bulk Actions', 'res-pong') . '</option><option value="delete">' . esc_html__('Delete', 'res-pong') . '</option><option value="enable">' . esc_html__('Enable', 'res-pong') . '</option><option value="disable">' . esc_html__('Disable', 'res-pong') . '</option></select> <button class="button" id="rp-apply-bulk">' . esc_html__('Apply', 'res-pong') . '</button> <label><input type="checkbox" id="rp-open-filter" checked> ' . esc_html__('Open only', 'res-pong') . '</label></div></div>';
         echo '<table id="res-pong-list" class="display" data-entity="events"></table>';
         $this->render_progress_overlay();
@@ -59,7 +59,7 @@ class Res_Pong_Admin {
 
     public function render_reservations_page() {
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__('Reservations', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a></h1>';
+        echo '<h1>' . esc_html__('Reservations', 'res-pong') . ' <a href="#" id="res-pong-add" class="page-title-action">' . esc_html__('Add New', 'res-pong') . '</a> <a href="#" id="res-pong-import" class="page-title-action">' . esc_html__('Import CSV', 'res-pong') . '</a> <a href="#" id="res-pong-export" class="page-title-action">' . esc_html__('Export CSV', 'res-pong') . '</a></h1>';
         echo '<div class="tablenav top"><div class="alignleft actions"><select id="rp-bulk-action"><option value="">' . esc_html__('Bulk Actions', 'res-pong') . '</option><option value="delete">' . esc_html__('Delete', 'res-pong') . '</option><option value="enable">' . esc_html__('Enable', 'res-pong') . '</option><option value="disable">' . esc_html__('Disable', 'res-pong') . '</option></select> <button class="button" id="rp-apply-bulk">' . esc_html__('Apply', 'res-pong') . '</button> <label><input type="checkbox" id="rp-active-filter" checked> ' . esc_html__('Active only', 'res-pong') . '</label></div></div>';
         echo '<table id="res-pong-list" class="display" data-entity="reservations"></table>';
         $this->render_progress_overlay();

--- a/includes/class-res-pong-repository.php
+++ b/includes/class-res-pong-repository.php
@@ -170,4 +170,56 @@ class Res_Pong_Repository {
         return $this->wpdb->delete($this->table_reservation, ['id' => $id]);
     }
 
+    private function rows_to_csv($rows) {
+        $fh = fopen('php://temp', 'r+');
+        if (!empty($rows)) {
+            fputcsv($fh, array_keys($rows[0]));
+            foreach ($rows as $row) {
+                fputcsv($fh, $row);
+            }
+        }
+        rewind($fh);
+        $csv = stream_get_contents($fh);
+        fclose($fh);
+        return $csv;
+    }
+
+    private function import_csv($file, $table) {
+        $handle = fopen($file, 'r');
+        if (!$handle) {
+            return false;
+        }
+        $header = fgetcsv($handle);
+        while (($data = fgetcsv($handle)) !== false) {
+            $row = array_combine($header, $data);
+            $this->wpdb->replace($table, $row);
+        }
+        fclose($handle);
+        return true;
+    }
+
+    public function export_users_csv() {
+        return $this->rows_to_csv($this->get_users());
+    }
+
+    public function import_users_csv($file) {
+        return $this->import_csv($file, $this->table_user);
+    }
+
+    public function export_events_csv() {
+        return $this->rows_to_csv($this->get_events(false));
+    }
+
+    public function import_events_csv($file) {
+        return $this->import_csv($file, $this->table_event);
+    }
+
+    public function export_reservations_csv() {
+        return $this->rows_to_csv($this->get_reservations(null, null, false));
+    }
+
+    public function import_reservations_csv($file) {
+        return $this->import_csv($file, $this->table_reservation);
+    }
+
 }

--- a/includes/class-res-pong-rest.php
+++ b/includes/class-res-pong-rest.php
@@ -47,6 +47,16 @@ class Res_Pong_Rest {
             'callback' => [ $this, 'rest_reset_password' ],
             'permission_callback' => function () { return current_user_can('manage_options'); },
         ]);
+        register_rest_route($namespace, '/users/export', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_export_users' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/users/import', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'rest_import_users' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
 
         // Events
         register_rest_route($namespace, '/events', [
@@ -74,6 +84,16 @@ class Res_Pong_Rest {
             'callback' => [ $this, 'rest_delete_event' ],
             'permission_callback' => function () { return current_user_can('manage_options'); },
         ]);
+        register_rest_route($namespace, '/events/export', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_export_events' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/events/import', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'rest_import_events' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
 
         // Reservations
         register_rest_route($namespace, '/reservations', [
@@ -99,6 +119,16 @@ class Res_Pong_Rest {
         register_rest_route($namespace, '/reservations/(?P<id>\d+)', [
             'methods'  => 'DELETE',
             'callback' => [ $this, 'rest_delete_reservation' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/reservations/export', [
+            'methods'  => 'GET',
+            'callback' => [ $this, 'rest_export_reservations' ],
+            'permission_callback' => function () { return current_user_can('manage_options'); },
+        ]);
+        register_rest_route($namespace, '/reservations/import', [
+            'methods'  => 'POST',
+            'callback' => [ $this, 'rest_import_reservations' ],
             'permission_callback' => function () { return current_user_can('manage_options'); },
         ]);
     }
@@ -216,6 +246,57 @@ class Res_Pong_Rest {
         $id = (int) $request['id'];
         $this->repository->delete_reservation($id);
         return new WP_REST_Response(null, 204);
+    }
+
+    public function rest_export_users() {
+        $csv = $this->repository->export_users_csv();
+        $response = new WP_REST_Response($csv, 200);
+        $response->header('Content-Type', 'text/csv; charset=UTF-8');
+        $response->header('Content-Disposition', 'attachment; filename="users.csv"');
+        return $response;
+    }
+
+    public function rest_import_users($request) {
+        $files = $request->get_file_params();
+        if (empty($files['file'])) {
+            return new WP_Error('no_file', 'No file uploaded', [ 'status' => 400 ]);
+        }
+        $this->repository->import_users_csv($files['file']['tmp_name']);
+        return new WP_REST_Response(null, 200);
+    }
+
+    public function rest_export_events() {
+        $csv = $this->repository->export_events_csv();
+        $response = new WP_REST_Response($csv, 200);
+        $response->header('Content-Type', 'text/csv; charset=UTF-8');
+        $response->header('Content-Disposition', 'attachment; filename="events.csv"');
+        return $response;
+    }
+
+    public function rest_import_events($request) {
+        $files = $request->get_file_params();
+        if (empty($files['file'])) {
+            return new WP_Error('no_file', 'No file uploaded', [ 'status' => 400 ]);
+        }
+        $this->repository->import_events_csv($files['file']['tmp_name']);
+        return new WP_REST_Response(null, 200);
+    }
+
+    public function rest_export_reservations() {
+        $csv = $this->repository->export_reservations_csv();
+        $response = new WP_REST_Response($csv, 200);
+        $response->header('Content-Type', 'text/csv; charset=UTF-8');
+        $response->header('Content-Disposition', 'attachment; filename="reservations.csv"');
+        return $response;
+    }
+
+    public function rest_import_reservations($request) {
+        $files = $request->get_file_params();
+        if (empty($files['file'])) {
+            return new WP_Error('no_file', 'No file uploaded', [ 'status' => 400 ]);
+        }
+        $this->repository->import_reservations_csv($files['file']['tmp_name']);
+        return new WP_REST_Response(null, 200);
     }
 }
 


### PR DESCRIPTION
## Summary
- add repository helpers to convert users, events, and reservations to/from CSV
- expose CSV import/export via new REST endpoints
- wire buttons and handlers in the admin interface for CSV upload/download

## Testing
- `php -l includes/class-res-pong-repository.php`
- `php -l includes/class-res-pong-rest.php`
- `php -l includes/class-res-pong-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689dd41d9b9483289e2e7caeecdd8819