### PR TITLE
Add event grouping and recurrence support

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -68,7 +68,13 @@
             { data: null, title: '', orderable: false, render: renderCheckbox },
             { data: 'name', title: 'Nome', render: function(d, type, row){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-event-detail&id=' + row.id + '">' + d + '</a>'; } },
             { data: 'id', title: 'ID', render: function(d){ return '<a href="' + rp_admin.admin_url + '?page=res-pong-event-detail&id=' + d + '">' + d + '</a>'; } },
-            { data: 'group_id', title: 'Gruppo' },
+            { data: 'group_id', title: 'Gruppo', render: function(d, type, row){
+                if(!d){ return ''; }
+                if(type === 'display'){
+                    return '<a href="' + rp_admin.admin_url + '?page=res-pong-event-detail&id=' + d + '">' + row.group_name + ' (' + d + ')</a>';
+                }
+                return d;
+            } },
             { data: 'start_datetime', title: 'Inizio' },
             { data: 'end_datetime', title: 'Fine' },
             { data: 'category', title: 'Categoria' },
@@ -97,10 +103,15 @@
         });
         table.on('click', '.rp-delete', function(){
             var id = $(this).data('id');
+            var row = table.DataTable().row($(this).closest('tr')).data();
+            var url = rp_admin.rest_url + entity + '/' + id;
+            if(entity === 'events' && row.group_id){
+                if(confirm('Applicare la modifica a tutta la serie di eventi?')){ url += '?apply_group=1'; }
+            }
             if(!confirm('Delete item?')){ return; }
             showOverlay(true);
             $.ajax({
-                url: rp_admin.rest_url + entity + '/' + id,
+                url: url,
                 method: 'DELETE',
                 beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
                 complete: function(){ hideOverlay(); },
@@ -116,9 +127,13 @@
             }else{
                 data.enabled = row.enabled == 1 ? 0 : 1;
             }
+            var url = rp_admin.rest_url + entity + '/' + id;
+            if(entity === 'events' && row.group_id){
+                if(confirm('Applicare la modifica a tutta la serie di eventi?')){ url += '?apply_group=1'; }
+            }
             showOverlay(true);
             $.ajax({
-                url: rp_admin.rest_url + entity + '/' + id,
+                url: url,
                 method: 'PUT',
                 contentType: 'application/json',
                 data: JSON.stringify(data),
@@ -128,7 +143,8 @@
             });
         });
     }
-    function initTable(table, entity, urlFunc){
+    function initTable(table, entity, urlFunc, opts){
+        opts = opts || {};
         var dt = table.DataTable({
             ajax: {
                 url: urlFunc(),
@@ -173,13 +189,20 @@
         var importBtn = $('<button class="button" id="res-pong-import">Importa CSV</button>');
         var exportBtn = $('<button class="button" id="res-pong-export">Esporta CSV</button>');
         toolbar.append(separator0, bulk);
-        toolbar.append(separator1, addBtn, separator2, importBtn, exportBtn);
+        toolbar.append(separator1, addBtn);
+        if(!opts.noCsv){
+            toolbar.append(separator2, importBtn, exportBtn);
+        }
         toolbar.append(filter);
         wrapper.prepend(toolbar);
 
         addBtn.on('click', function(e){
             e.preventDefault();
-            window.location = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail';
+            var url = rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail';
+            if(opts.addParams){
+                url += '&' + opts.addParams;
+            }
+            window.location = url;
         });
         exportBtn.on('click', function(e){
             e.preventDefault();
@@ -281,6 +304,9 @@
         if(!form.length){ return; }
         var entity = form.data('entity');
         var id = form.data('id');
+        var params = new URLSearchParams(window.location.search);
+        var preUser = params.get('user_id');
+        var preEvent = params.get('event_id');
         function loadReservationOptions(callback){
             var uReq = $.ajax({
                 url: rp_admin.rest_url + 'users',
@@ -304,12 +330,52 @@
                     var dt = e.start_datetime.substring(0,16);
                     eSel.append('<option value="' + e.id + '">' + e.name + ' - ' + dt + ' (' + e.id + ')</option>');
                 });
+                if(!id){
+                    if(preUser){ uSel.val(preUser); }
+                    if(preEvent){ eSel.val(preEvent); }
+                }
                 if(callback){ callback(); }
             });
+        }
+        function loadEventGroupOptions(callback){
+            $.ajax({
+                url: rp_admin.rest_url + 'events&open_only=0',
+                method: 'GET',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                success: function(events){
+                    var sel = $('#group_id');
+                    sel.append('<option value="">Nessuno</option>');
+                    $.each(events, function(_, e){
+                        sel.append('<option value="' + e.id + '">' + e.name + ' (' + e.id + ')</option>');
+                    });
+                    if(callback){ callback(); }
+                }
+            });
+        }
+        function setupRecurrence(){
+            function toggle(){
+                if($('#group_id').val()){
+                    $('#recurrence_row, #recurrence_end_row').hide();
+                }else{
+                    $('#recurrence_row, #recurrence_end_row').show();
+                    $('#recurrence_end').prop('disabled', $('#recurrence').val() === 'none');
+                }
+            }
+            $('#group_id').on('change', toggle);
+            $('#recurrence').on('change', function(){
+                $('#recurrence_end').prop('disabled', $('#recurrence').val() === 'none');
+            });
+            if(id){
+                $('#recurrence_row, #recurrence_end_row').hide();
+            }else{
+                toggle();
+            }
         }
         function initForm(){ if(id){ populateForm(entity, id, form); } }
         if(entity === 'reservations'){
             loadReservationOptions(initForm);
+        }else if(entity === 'events'){
+            loadEventGroupOptions(function(){ initForm(); setupRecurrence(); });
         }else{
             initForm();
         }
@@ -321,6 +387,9 @@
             form.find('input[type=datetime-local]').each(function(){ data[this.name] = this.value.replace('T', ' '); });
             var method = id ? 'PUT' : 'POST';
             var url = rp_admin.rest_url + entity + (id ? '/' + id : '');
+            if(entity === 'events' && id && $('#group_id').val()){
+                if(confirm('Applicare la modifica a tutta la serie di eventi?')){ url += '?apply_group=1'; }
+            }
             showOverlay(true);
             $.ajax({
                 url: url,
@@ -335,6 +404,9 @@
                         id = resp.id;
                         form.attr('data-id', id);
                         history.replaceState(null, '', rp_admin.admin_url + '?page=res-pong-' + entity.slice(0,-1) + '-detail&id=' + id);
+                        if(entity === 'events'){
+                            $('#recurrence_row, #recurrence_end_row').hide();
+                        }
                     }
                 },
                 error: function(){
@@ -344,10 +416,19 @@
         });
         $('#res-pong-delete').on('click', function(e){
             e.preventDefault();
-            if(!id || !confirm('Delete item?')){ return; }
+            if(!id){ return; }
+            var url = rp_admin.rest_url + entity + '/' + id;
+            var proceed = true;
+            if(entity === 'events' && $('#group_id').val()){
+                if(confirm('Applicare la modifica a tutta la serie di eventi?')){ url += '?apply_group=1'; }
+                proceed = confirm('Delete item?');
+            }else{
+                proceed = confirm('Delete item?');
+            }
+            if(!proceed){ return; }
             showOverlay(true);
             $.ajax({
-                url: rp_admin.rest_url + entity + '/' + id,
+                url: url,
                 method: 'DELETE',
                 beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
                 complete: function(){ hideOverlay(); },
@@ -429,12 +510,12 @@
         var ur = $('#res-pong-user-reservations');
         if(ur.length){
             var uid = ur.data('user');
-            initTable(ur, 'reservations', function(){ return restUrl('reservations', 'user_id=' + uid + '&active_only=1'); });
+            initTable(ur, 'reservations', function(){ return restUrl('reservations', 'user_id=' + uid + '&active_only=1'); }, { addParams: 'user_id=' + uid, noCsv: true });
         }
         var er = $('#res-pong-event-reservations');
         if(er.length){
             var eid = er.data('event');
-            initTable(er, 'reservations', function(){ return restUrl('reservations', 'event_id=' + eid + '&active_only=1'); });
+            initTable(er, 'reservations', function(){ return restUrl('reservations', 'event_id=' + eid + '&active_only=1'); }, { addParams: 'event_id=' + eid, noCsv: true });
         }
         initDetail();
     });

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -116,7 +116,9 @@ class Res_Pong_Admin {
         echo '<h1>' . ($editing ? esc_html__('Edit Event', 'res-pong') : esc_html__('Add Event', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="events" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
-        echo '<tr><th><label for="group_id">Group ID</label></th><td><input name="group_id" id="group_id" type="number"></td></tr>';
+        echo '<tr><th><label for="group_id">Group ID</label></th><td><select name="group_id" id="group_id"></select></td></tr>';
+        echo '<tr id="recurrence_row"><th><label for="recurrence">Ricorrenza</label></th><td><select name="recurrence" id="recurrence"><option value="none">Mai</option><option value="daily">Giornaliera</option><option value="weekly">Settimanale</option><option value="monthly">Mensile</option></select></td></tr>';
+        echo '<tr id="recurrence_end_row"><th><label for="recurrence_end">Termine ricorrenza</label></th><td><input name="recurrence_end" id="recurrence_end" type="date" disabled></td></tr>';
         echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
         echo '<tr><th><label for="name">Name</label></th><td><input name="name" id="name" type="text"></td></tr>';
         echo '<tr><th><label for="note">Note</label></th><td><textarea name="note" id="note"></textarea></td></tr>';

--- a/includes/class-res-pong-repository.php
+++ b/includes/class-res-pong-repository.php
@@ -107,7 +107,7 @@ class Res_Pong_Repository {
             $now = current_time('mysql');
             $where = $this->wpdb->prepare('WHERE e.start_datetime > %s', $now);
         }
-        $sql = "SELECT e.*, COUNT(r.id) AS players_count FROM {$this->table_event} e LEFT JOIN {$this->table_reservation} r ON e.id = r.event_id {$where} GROUP BY e.id";
+        $sql = "SELECT e.*, g.name AS group_name, COUNT(r.id) AS players_count FROM {$this->table_event} e LEFT JOIN {$this->table_event} g ON e.group_id = g.id LEFT JOIN {$this->table_reservation} r ON e.id = r.event_id {$where} GROUP BY e.id";
         return $this->wpdb->get_results($sql, ARRAY_A);
     }
 
@@ -116,7 +116,8 @@ class Res_Pong_Repository {
     }
 
     public function insert_event($data) {
-        return $this->wpdb->insert($this->table_event, $data);
+        $this->wpdb->insert($this->table_event, $data);
+        return $this->wpdb->insert_id;
     }
 
     public function update_event($id, $data) {
@@ -125,6 +126,14 @@ class Res_Pong_Repository {
 
     public function delete_event($id) {
         return $this->wpdb->delete($this->table_event, ['id' => $id]);
+    }
+
+    public function update_events_by_group($group_id, $data) {
+        return $this->wpdb->update($this->table_event, $data, ['group_id' => $group_id]);
+    }
+
+    public function delete_events_by_group($group_id) {
+        return $this->wpdb->delete($this->table_event, ['group_id' => $group_id]);
     }
 
     // ------------------------

--- a/includes/class-res-pong-rest.php
+++ b/includes/class-res-pong-rest.php
@@ -184,20 +184,77 @@ class Res_Pong_Rest {
 
     public function rest_create_event($request) {
         $data = $request->get_json_params();
-        $this->repository->insert_event($data);
+        $group_id = isset($data['group_id']) && $data['group_id'] !== '' ? (int) $data['group_id'] : null;
+        $recurrence = isset($data['recurrence']) ? $data['recurrence'] : 'none';
+        $recurrence_end = isset($data['recurrence_end']) ? $data['recurrence_end'] : null;
+        unset($data['recurrence'], $data['recurrence_end']);
+        if ($group_id) {
+            $data['group_id'] = $group_id;
+            $id = $this->repository->insert_event($data);
+            $data['id'] = $id;
+            return new WP_REST_Response($data, 201);
+        }
+        $data['group_id'] = null;
+        $id = $this->repository->insert_event($data);
+        $data['id'] = $id;
+        if ($recurrence !== 'none' && $recurrence_end) {
+            $this->repository->update_event($id, [ 'group_id' => $id ]);
+            $start = new DateTime($data['start_datetime']);
+            $end = new DateTime($data['end_datetime']);
+            $limit = new DateTime($recurrence_end . ' 23:59:59');
+            switch ($recurrence) {
+                case 'daily': $interval = new DateInterval('P1D'); break;
+                case 'weekly': $interval = new DateInterval('P1W'); break;
+                case 'monthly': $interval = new DateInterval('P1M'); break;
+                default: $interval = null; break;
+            }
+            if ($interval) {
+                while (true) {
+                    $start->add($interval);
+                    $end->add($interval);
+                    if ($start > $limit) { break; }
+                    $e = $data;
+                    $e['start_datetime'] = $start->format('Y-m-d H:i:s');
+                    $e['end_datetime'] = $end->format('Y-m-d H:i:s');
+                    $e['group_id'] = $id;
+                    $this->repository->insert_event($e);
+                }
+            }
+            $data['group_id'] = $id;
+        }
         return new WP_REST_Response($data, 201);
     }
 
     public function rest_update_event($request) {
         $id = (int) $request['id'];
         $data = $request->get_json_params();
-        $this->repository->update_event($id, $data);
+        $apply = $request->get_param('apply_group');
+        if ($apply) {
+            $event = $this->repository->get_event($id);
+            if ($event && $event['group_id']) {
+                $this->repository->update_events_by_group($event['group_id'], $data);
+            } else {
+                $this->repository->update_event($id, $data);
+            }
+        } else {
+            $this->repository->update_event($id, $data);
+        }
         return rest_ensure_response($this->repository->get_event($id));
     }
 
     public function rest_delete_event($request) {
         $id = (int) $request['id'];
-        $this->repository->delete_event($id);
+        $apply = $request->get_param('apply_group');
+        if ($apply) {
+            $event = $this->repository->get_event($id);
+            if ($event && $event['group_id']) {
+                $this->repository->delete_events_by_group($event['group_id']);
+            } else {
+                $this->repository->delete_event($id);
+            }
+        } else {
+            $this->repository->delete_event($id);
+        }
         return new WP_REST_Response(null, 204);
     }
 


### PR DESCRIPTION
## Summary
- show master event links in event lists
- allow creating recurring events and groups via admin
- remove CSV controls from nested reservation tables and prefill context on add

## Testing
- `php -l includes/class-res-pong-admin.php`
- `php -l includes/class-res-pong-repository.php`
- `php -l includes/class-res-pong-rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689e02b109a48328a1ca905b6cf55f88