### PR TITLE
Add event grouping and recurrence support

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -77,6 +77,22 @@ button.rp-unsign,
     border-color: #8e0000 !important;
     background: #fff !important;
 }
+
+.rp-button-add {
+    color: #2e7d32 !important;
+    border-color: #2e7d32 !important;
+    background: #fff !important;
+}
+
+.rp-button-add:hover {
+    color: #1b5e20 !important;
+    border-color: #1b5e20 !important;
+    background: #fff !important;
+}
+
+.rp-button-add .dashicons {
+    margin-right: 2px;
+}
 .rp-toolbar {
     display: flex;
     align-items: center;

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -71,7 +71,7 @@ class Res_Pong_Admin {
         echo '<h1>' . ($editing ? esc_html__('Edit User', 'res-pong') : esc_html__('Add User', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="users" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
-        echo '<tr><th><label for="id">ID</label></th><td><input name="id" id="id" type="text"></td></tr>';
+        echo '<tr><th><label for="id">ID</label></th><td><input name="id" id="id" type="text"' . ( $editing ? ' readonly' : '' ) . '></td></tr>';
         echo '<tr><th><label for="email">Email</label></th><td><input name="email" id="email" type="email"></td></tr>';
         echo '<tr><th><label for="username">Username</label></th><td><input name="username" id="username" type="text"></td></tr>';
         echo '<tr><th><label for="first_name">First Name</label></th><td><input name="first_name" id="first_name" type="text"></td></tr>';
@@ -112,16 +112,20 @@ class Res_Pong_Admin {
     public function render_event_detail() {
         $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
         $editing = !empty($id);
+        $default_start = date('Y-m-d\\T21:30:00');
+        $default_end = date('Y-m-d\\T23:00:00');
         echo '<div class="wrap">';
         echo '<h1>' . ($editing ? esc_html__('Edit Event', 'res-pong') : esc_html__('Add Event', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="events" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
-        echo '<tr><th><label for="group_id">Group ID</label></th><td><input name="group_id" id="group_id" type="number"></td></tr>';
+        echo '<tr><th><label for="group_id">Group ID</label></th><td><select name="group_id" id="group_id"></select></td></tr>';
+        echo '<tr id="recurrence_row"><th><label for="recurrence">Ricorrenza</label></th><td><select name="recurrence" id="recurrence"><option value="none">Mai</option><option value="daily">Giornaliera</option><option value="weekly">Settimanale</option><option value="monthly">Mensile</option></select></td></tr>';
+        echo '<tr id="recurrence_end_row"><th><label for="recurrence_end">Termine ricorrenza</label></th><td><input name="recurrence_end" id="recurrence_end" type="date" disabled></td></tr>';
         echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
         echo '<tr><th><label for="name">Name</label></th><td><input name="name" id="name" type="text"></td></tr>';
         echo '<tr><th><label for="note">Note</label></th><td><textarea name="note" id="note"></textarea></td></tr>';
-        echo '<tr><th><label for="start_datetime">Start</label></th><td><input name="start_datetime" id="start_datetime" type="datetime-local" step="1"></td></tr>';
-        echo '<tr><th><label for="end_datetime">End</label></th><td><input name="end_datetime" id="end_datetime" type="datetime-local" step="1"></td></tr>';
+        echo '<tr><th><label for="start_datetime">Start</label></th><td><input name="start_datetime" id="start_datetime" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_start) . '"' ) . '></td></tr>';
+        echo '<tr><th><label for="end_datetime">End</label></th><td><input name="end_datetime" id="end_datetime" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_end) . '"' ) . '></td></tr>';
         echo '<tr><th><label for="max_players">Max Players</label></th><td><input name="max_players" id="max_players" type="number"></td></tr>';
         echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"' . ( $editing ? '' : ' checked' ) . '></td></tr>';
         echo '</table>';
@@ -140,13 +144,14 @@ class Res_Pong_Admin {
     public function render_reservation_detail() {
         $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
         $editing = !empty($id);
+        $default_created = date('Y-m-d\\TH:i:s');
         echo '<div class="wrap">';
         echo '<h1>' . ($editing ? esc_html__('Edit Reservation', 'res-pong') : esc_html__('Add Reservation', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="reservations" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
         echo '<tr><th><label for="user_id">User ID</label></th><td><select name="user_id" id="user_id"></select></td></tr>';
         echo '<tr><th><label for="event_id">Event ID</label></th><td><select name="event_id" id="event_id"></select></td></tr>';
-        echo '<tr><th><label for="created_at">Created At</label></th><td><input name="created_at" id="created_at" type="datetime-local" step="1"></td></tr>';
+        echo '<tr><th><label for="created_at">Created At</label></th><td><input name="created_at" id="created_at" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_created) . '"' ) . '></td></tr>';
         echo '<tr><th><label for="presence_confirmed">Presence Confirmed</label></th><td><input name="presence_confirmed" id="presence_confirmed" type="checkbox" value="1"></td></tr>';
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';

--- a/includes/class-res-pong-repository.php
+++ b/includes/class-res-pong-repository.php
@@ -107,7 +107,7 @@ class Res_Pong_Repository {
             $now = current_time('mysql');
             $where = $this->wpdb->prepare('WHERE e.start_datetime > %s', $now);
         }
-        $sql = "SELECT e.*, COUNT(r.id) AS players_count FROM {$this->table_event} e LEFT JOIN {$this->table_reservation} r ON e.id = r.event_id {$where} GROUP BY e.id";
+        $sql = "SELECT e.*, g.name AS group_name, COUNT(r.id) AS players_count FROM {$this->table_event} e LEFT JOIN {$this->table_event} g ON e.group_id = g.id LEFT JOIN {$this->table_reservation} r ON e.id = r.event_id {$where} GROUP BY e.id";
         return $this->wpdb->get_results($sql, ARRAY_A);
     }
 
@@ -116,7 +116,8 @@ class Res_Pong_Repository {
     }
 
     public function insert_event($data) {
-        return $this->wpdb->insert($this->table_event, $data);
+        $this->wpdb->insert($this->table_event, $data);
+        return $this->wpdb->insert_id;
     }
 
     public function update_event($id, $data) {
@@ -125,6 +126,14 @@ class Res_Pong_Repository {
 
     public function delete_event($id) {
         return $this->wpdb->delete($this->table_event, ['id' => $id]);
+    }
+
+    public function update_events_by_group($group_id, $data) {
+        return $this->wpdb->update($this->table_event, $data, ['group_id' => $group_id]);
+    }
+
+    public function delete_events_by_group($group_id) {
+        return $this->wpdb->delete($this->table_event, ['group_id' => $group_id]);
     }
 
     // ------------------------


### PR DESCRIPTION
## Summary
- show master event links in event lists
- allow creating recurring events and groups via admin
- remove CSV controls from nested reservation tables and prefill context on add
- prefill new reservation datetime with current timestamp
- default new events to 21:30 start and 23:00 end
- make user ID read-only in edit form
- fix recurring event creation by letting the database assign IDs to generated events
- style Add buttons with a leading plus icon and green outline

## Testing
- `php -l includes/class-res-pong-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689e02b109a48328a1ca905b6cf55f88