### PR TITLE
Handle direct password update and reorganize user actions

### DIFF
--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -125,10 +125,11 @@ class Res_Pong_Admin {
         echo '<tr><th><label for="new_password">New Password</label></th><td><input name="new_password" id="new_password" type="password"></td></tr>';
         echo '<tr><th><label for="confirm_password">Confirm Password</label></th><td><input name="confirm_password" id="confirm_password" type="password"></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save Password', 'res-pong') . '</button> ';
-        echo '<button type="button" class="button" id="res-pong-invite">' . esc_html__('Invita', 'res-pong') . '</button> ';
-        echo '<button type="button" class="button" id="res-pong-reset-password">' . esc_html__('Reset Password', 'res-pong') . '</button></p>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save Password', 'res-pong') . '</button></p>';
         echo '</form>';
+        echo '<h2>' . esc_html__('Password Email Operation', 'res-pong') . '</h2>';
+        echo '<p><button type="button" class="button" id="res-pong-invite">' . esc_html__('Invita', 'res-pong') . '</button> ';
+        echo '<button type="button" class="button" id="res-pong-reset-password">' . esc_html__('Reset Password', 'res-pong') . '</button></p>';
         $default_timeout = date('Y-m-d\\T00:00:00', strtotime('+7 days'));
         echo '<h2>' . esc_html__('Timeout', 'res-pong') . '</h2>';
         echo '<form id="res-pong-timeout-form" data-entity="users" data-id="' . esc_attr($id) . '">';

--- a/includes/class-res-pong-rest.php
+++ b/includes/class-res-pong-rest.php
@@ -290,6 +290,16 @@ class Res_Pong_Rest {
         if (!$user) {
             return new WP_Error('not_found', 'User not found', [ 'status' => 404 ]);
         }
+        $params = $request->get_json_params();
+        $password = isset($params['password']) ? $params['password'] : '';
+        if (!empty($password)) {
+            if (strlen($password) < 6) {
+                return new WP_Error('invalid_password', 'Password must be at least 6 characters', [ 'status' => 400 ]);
+            }
+            $hashed = password_hash($password, PASSWORD_DEFAULT);
+            $this->repository->update_user($id, [ 'password' => $hashed, 'reset_token' => null ]);
+            return new WP_REST_Response([ 'success' => true ], 200);
+        }
         $token = $this->generate_reset_token();
         $this->repository->update_user($id, [ 'reset_token' => $token ]);
         $config = new Res_Pong_Configuration();


### PR DESCRIPTION
## Summary
- Allow direct password updates via REST when a new password is provided.
- Separate password saving from invite/reset operations on the user detail screen.

## Testing
- `php -l includes/class-res-pong-rest.php`
- `php -l includes/class-res-pong-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689e2a52b2e0832885633dc292702987