### PR TITLE
Add user impersonation and adjust action buttons

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -55,7 +55,9 @@ button.rp-unsign,
     /*text-align: center;*/
 }
 .rp-action-btn {
-    width: 90px;
+    width: 80px;
+    font-size: 11px;
+    padding: 0 6px;
 }
 .rp-button-enable {
     color: #2e7d32 !important;

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -56,11 +56,14 @@
         }
         toggleClass = state ? 'rp-button-disable' : 'rp-button-enable';
         var toggle = '<button class="button rp-toggle rp-action-btn ' + toggleClass + '" data-id="' + data.id + '">' + toggleLabel + '</button>';
-        var extra = '';
-        if(entity === 'users' && !data.password){
-            extra = ' <button class="button rp-invite rp-action-btn" data-id="' + data.id + '">Invita</button>';
+        var buttons = edit + ' ' + del + ' ' + toggle;
+        if(entity === 'users'){
+            buttons += ' <button class="button rp-impersonate rp-action-btn" data-id="' + data.id + '">Impersona</button>';
+            if(!data.password){
+                buttons += ' <button class="button rp-invite rp-action-btn" data-id="' + data.id + '">Invita</button>';
+            }
         }
-        return edit + ' ' + del + ' ' + toggle + extra;
+        return buttons;
     }
     var columns = {
         users: [
@@ -178,6 +181,23 @@
                     success: function(){ showNotice('success', 'Invited'); },
                     error: function(xhr){
                         var msg = 'Invite failed';
+                        if(xhr.responseJSON && xhr.responseJSON.message){ msg += ': ' + xhr.responseJSON.message; }
+                        showNotice('error', msg);
+                    }
+                });
+            });
+            table.on('click', '.rp-impersonate', function(){
+                var id = $(this).data('id');
+                clearNotice();
+                showOverlay(true);
+                $.ajax({
+                    url: rp_admin.rest_url + 'users/' + id + '/impersonate',
+                    method: 'POST',
+                    beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                    complete: function(){ hideOverlay(); },
+                    success: function(resp){ if(resp && resp.url){ window.open(resp.url, '_blank'); } },
+                    error: function(xhr){
+                        var msg = 'Impersonation failed';
                         if(xhr.responseJSON && xhr.responseJSON.message){ msg += ': ' + xhr.responseJSON.message; }
                         showNotice('error', msg);
                     }
@@ -498,6 +518,23 @@
                 },
                 error: function(xhr){
                     var msg = 'Error deleting';
+                    if(xhr.responseJSON && xhr.responseJSON.message){ msg += ': ' + xhr.responseJSON.message; }
+                    showNotice('error', msg);
+                }
+            });
+        });
+        $('#res-pong-impersonate').on('click', function(){
+            if(!id){ return; }
+            clearNotice();
+            showOverlay(true);
+            $.ajax({
+                url: rp_admin.rest_url + 'users/' + id + '/impersonate',
+                method: 'POST',
+                beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                complete: function(){ hideOverlay(); },
+                success: function(resp){ if(resp && resp.url){ window.open(resp.url, '_blank'); } },
+                error: function(xhr){
+                    var msg = 'Impersonation failed';
                     if(xhr.responseJSON && xhr.responseJSON.message){ msg += ': ' + xhr.responseJSON.message; }
                     showNotice('error', msg);
                 }

--- a/includes/class-res-pong-admin.php
+++ b/includes/class-res-pong-admin.php
@@ -117,6 +117,7 @@ class Res_Pong_Admin {
         if ($editing) {
             echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
         }
+        echo ' <button type="button" class="button" id="res-pong-impersonate"' . ( $editing ? '' : ' disabled' ) . '>' . esc_html__('Impersona', 'res-pong') . '</button>';
         echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-users')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
         echo '</p></form>';
         echo '<h2>' . esc_html__('Password Reset', 'res-pong') . '</h2>';


### PR DESCRIPTION
## Summary
- add REST endpoint and admin controls to impersonate users
- expose "Impersona" actions in user list and detail pages
- shrink action button styling for denser tables

## Testing
- `php -l includes/class-res-pong-rest.php`
- `php -l includes/class-res-pong-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689e4387abe083288046017f10c1640f