### PR TITLE
Use icons for admin actions and expand configurations

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -54,10 +54,21 @@ button.rp-unsign,
 .rp-icon-col {
     /*text-align: center;*/
 }
+.rp-action-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+}
 .rp-action-btn {
-    width: 80px;
-    font-size: 11px;
-    padding: 0 6px;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+.rp-action-btn .dashicons {
+    margin: 0;
 }
 .rp-button-enable {
     color: #2e7d32 !important;

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -44,9 +44,9 @@
         return url;
     }
     function actionButtons(entity, data){
-        var edit = '<button class="button rp-edit rp-action-btn" data-id="' + data.id + '">Modifica</button>';
-        var del = '<button class="button rp-delete rp-button-danger rp-action-btn" data-id="' + data.id + '">Cancella</button>';
-        var toggleLabel, state, toggleClass;
+        var edit = '<button class="button rp-edit rp-action-btn" data-id="' + data.id + '" title="Modifica"><span class="dashicons dashicons-edit"></span></button>';
+        var del = '<button class="button rp-delete rp-button-danger rp-action-btn" data-id="' + data.id + '" title="Cancella"><span class="dashicons dashicons-trash"></span></button>';
+        var toggleLabel, state, toggleClass, toggleIcon;
         if(entity === 'reservations'){
             state = parseInt(data.presence_confirmed);
             toggleLabel = state ? 'Assente' : 'Presente';
@@ -55,15 +55,16 @@
             toggleLabel = state ? 'Disabilita' : 'Abilita';
         }
         toggleClass = state ? 'rp-button-disable' : 'rp-button-enable';
-        var toggle = '<button class="button rp-toggle rp-action-btn ' + toggleClass + '" data-id="' + data.id + '">' + toggleLabel + '</button>';
-        var buttons = edit + ' ' + del + ' ' + toggle;
+        toggleIcon = state ? 'dashicons-no-alt' : 'dashicons-yes';
+        var toggle = '<button class="button rp-toggle rp-action-btn ' + toggleClass + '" data-id="' + data.id + '" title="' + toggleLabel + '"><span class="dashicons ' + toggleIcon + '"></span></button>';
+        var buttons = edit + del + toggle;
         if(entity === 'users'){
-            buttons += ' <button class="button rp-impersonate rp-action-btn" data-id="' + data.id + '">Impersona</button>';
+            buttons += '<button class="button rp-impersonate rp-action-btn" data-id="' + data.id + '" title="Impersona"><span class="dashicons dashicons-admin-users"></span></button>';
             if(!data.password){
-                buttons += ' <button class="button rp-invite rp-action-btn" data-id="' + data.id + '">Invita</button>';
+                buttons += '<button class="button rp-invite rp-action-btn" data-id="' + data.id + '" title="Invita"><span class="dashicons dashicons-email"></span></button>';
             }
         }
-        return buttons;
+        return '<div class="rp-action-group">' + buttons + '</div>';
     }
     var columns = {
         users: [

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -78,6 +78,8 @@ class Res_Pong_Admin_Frontend {
                 'next_reservation_delay'   => isset($_POST['next_reservation_delay']) ? intval($_POST['next_reservation_delay']) : 0,
                 'first_access_page_url'    => isset($_POST['first_access_page_url']) ? esc_url_raw($_POST['first_access_page_url']) : '',
                 'password_update_page_url' => isset($_POST['password_update_page_url']) ? esc_url_raw($_POST['password_update_page_url']) : '',
+                'invitation_text'          => isset($_POST['invitation_text']) ? sanitize_textarea_field($_POST['invitation_text']) : '',
+                'reset_password_text'      => isset($_POST['reset_password_text']) ? sanitize_textarea_field($_POST['reset_password_text']) : '',
             ];
             $this->admin_service->update_configurations($data);
             echo '<div class="updated"><p>' . esc_html__('Settings saved', 'res-pong') . '</p></div>';
@@ -94,6 +96,8 @@ class Res_Pong_Admin_Frontend {
         echo '<tr><th><label for="next_reservation_delay">Next reservation delay</label></th><td><input name="next_reservation_delay" id="next_reservation_delay" type="number" value="' . esc_attr($config['next_reservation_delay']) . '"></td></tr>';
         echo '<tr><th><label for="first_access_page_url">First access page URL</label></th><td><input name="first_access_page_url" id="first_access_page_url" type="text" value="' . esc_attr($config['first_access_page_url']) . '"></td></tr>';
         echo '<tr><th><label for="password_update_page_url">Password update page URL</label></th><td><input name="password_update_page_url" id="password_update_page_url" type="text" value="' . esc_attr($config['password_update_page_url']) . '"></td></tr>';
+        echo '<tr><th><label for="invitation_text">Invitation Text</label></th><td><textarea name="invitation_text" id="invitation_text" rows="3" class="large-text">' . esc_textarea($config['invitation_text']) . '</textarea></td></tr>';
+        echo '<tr><th><label for="reset_password_text">Reset Password Text</label></th><td><textarea name="reset_password_text" id="reset_password_text" rows="3" class="large-text">' . esc_textarea($config['reset_password_text']) . '</textarea></td></tr>';
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button></p>';
         echo '</form>';

--- a/includes/common/class-res-pong-configuration.php
+++ b/includes/common/class-res-pong-configuration.php
@@ -9,6 +9,8 @@ class Res_Pong_Configuration {
         'next_reservation_delay' => 300,
         'first_access_page_url' => 'https://localhost/#/first-access',
         'password_update_page_url' => 'https://localhost/#/password-update',
+        'invitation_text' => '',
+        'reset_password_text' => '',
     ];
 
     public function get_all() {


### PR DESCRIPTION
## Summary
- Replace text action buttons with dashicon icons and flex layout
- Add invitation and reset password text fields in configurations

## Testing
- `php -l includes/common/class-res-pong-configuration.php`
- `php -l includes/admin/class-res-pong-admin-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed25b9cbc8328861017fa5dd4478f