### PR TITLE
Update admin REST API namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ L'interfaccia pubblica per gli utenti non è ancora stata implementata.
 4. Accedi alla voce **Res Pong** del menu di amministrazione per configurare il sistema.
 
 ## API
-Il plugin espone un endpoint REST con prefisso `/wp-json/res-pong/v1/` utilizzato dall'interfaccia di amministrazione.
+Il plugin espone un endpoint REST con prefisso `/wp-json/res-pong-admin/v1/` utilizzato dall'interfaccia di amministrazione.
 
 ## Roadmap
 - implementazione dell'area pubblica per i tesserati

--- a/includes/admin/class-res-pong-admin-controller.php
+++ b/includes/admin/class-res-pong-admin-controller.php
@@ -12,7 +12,7 @@ class Res_Pong_Admin_Controller {
     }
 
     public function register_routes() {
-        $namespace = 'res-pong/v1';
+        $namespace = 'res-pong-admin/v1';
 
         // Users
         register_rest_route($namespace, '/users', [

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -38,7 +38,7 @@ class Res_Pong_Admin_Frontend {
         wp_enqueue_script('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js', [ 'jquery' ], null, true);
         wp_enqueue_script('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/js/res-pong-admin.js', [ 'jquery', 'res-pong-datatables' ], RES_PONG_VERSION, true);
         wp_localize_script('res-pong-admin', 'rp_admin', [
-            'rest_url'  => esc_url_raw(rest_url('res-pong/v1/')),
+            'rest_url'  => esc_url_raw(rest_url('res-pong-admin/v1/')),
             'nonce'     => wp_create_nonce('wp_rest'),
             'admin_url' => admin_url('admin.php'),
         ]);


### PR DESCRIPTION
## Summary
- change admin REST namespace to `res-pong-admin/v1`
- update localized REST URL for admin scripts
- document new admin REST endpoint prefix

## Testing
- `php -l includes/admin/class-res-pong-admin-controller.php`
- `php -l includes/admin/class-res-pong-admin-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_689ee6cf8f78832899344141cde96475