### PR TITLE
Make DataTables responsive for mobile

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -137,8 +137,22 @@ button.rp-unsign,
     align-items: center;
     gap: 10px;
     margin-bottom: 10px;
+    flex-wrap: wrap;
 }
 
 .rp-toolbar .dataTables_filter {
     margin-left: auto;
+}
+
+@media (max-width: 600px) {
+    .rp-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .rp-toolbar .dataTables_filter,
+    .rp-toolbar .dataTables_length,
+    .rp-toolbar .rp-bulk {
+        width: 100%;
+        margin-left: 0;
+    }
 }

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -221,7 +221,8 @@
                 beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); }
             },
             columns: columns[entity],
-            order: order
+            order: order,
+            responsive: true
         });
         dt.on('preXhr.dt', function(){ showOverlay(true); });
         dt.on('xhr.dt error.dt', function(){ hideOverlay(); });

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -34,9 +34,11 @@ class Res_Pong_Admin_Frontend {
             return;
         }
         wp_enqueue_style('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css');
+        wp_enqueue_style('res-pong-datatables-responsive', 'https://cdn.datatables.net/responsive/2.4.1/css/responsive.dataTables.min.css');
         wp_enqueue_style('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/css/res-pong-admin.css', [], RES_PONG_VERSION);
         wp_enqueue_script('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js', [ 'jquery' ], null, true);
-        wp_enqueue_script('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/js/res-pong-admin.js', [ 'jquery', 'res-pong-datatables' ], RES_PONG_VERSION, true);
+        wp_enqueue_script('res-pong-datatables-responsive', 'https://cdn.datatables.net/responsive/2.4.1/js/dataTables.responsive.min.js', [ 'res-pong-datatables' ], null, true);
+        wp_enqueue_script('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/js/res-pong-admin.js', [ 'jquery', 'res-pong-datatables', 'res-pong-datatables-responsive' ], RES_PONG_VERSION, true);
         wp_localize_script('res-pong-admin', 'rp_admin', [
             'rest_url'  => esc_url_raw(rest_url('res-pong-admin/v1/')),
             'nonce'     => wp_create_nonce('wp_rest'),


### PR DESCRIPTION
## Summary
- Load DataTables responsive assets and wire them into admin scripts
- Initialize DataTables with responsive behavior
- Tweak admin toolbar layout for small screens

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eefed80788328b27d873e5f9db72f