### PR TITLE
feat(admin): improve event and reservation handling

### DIFF
--- a/includes/admin/class-res-pong-admin-repository.php
+++ b/includes/admin/class-res-pong-admin-repository.php
@@ -126,6 +126,7 @@ class Res_Pong_Admin_Repository {
     }
 
     public function delete_event($id) {
+        $this->wpdb->update($this->table_event, ['group_id' => null], ['group_id' => $id]);
         return $this->wpdb->delete($this->table_event, ['id' => $id]);
     }
 

--- a/includes/admin/class-res-pong-admin-service.php
+++ b/includes/admin/class-res-pong-admin-service.php
@@ -64,6 +64,22 @@ class Res_Pong_Admin_Service {
         $group_id = isset($data['group_id']) && $data['group_id'] !== '' ? (int)$data['group_id'] : null;
         $recurrence = isset($data['recurrence']) ? $data['recurrence'] : 'none';
         $recurrence_end = isset($data['recurrence_end']) ? $data['recurrence_end'] : null;
+        if (isset($data['start_datetime'])) {
+            $start_dt = new DateTime($data['start_datetime']);
+            $data['start_datetime'] = $start_dt->format('Y-m-d H:i:s');
+        }
+        if (isset($data['end_datetime'])) {
+            $end_dt = new DateTime($data['end_datetime']);
+            $data['end_datetime'] = $end_dt->format('Y-m-d H:i:s');
+        }
+        if ($recurrence !== 'none' && $recurrence_end) {
+            $limit = new DateTime();
+            $limit->add(new DateInterval('P1Y1D'));
+            $recurrence_end_dt = new DateTime($recurrence_end);
+            if ($recurrence_end_dt > $limit) {
+                return new WP_Error('invalid_recurrence_end', 'Il termine di ricorrenza non può superare un anno e un giorno da adesso', ['status' => 400]);
+            }
+        }
         unset($data['recurrence'], $data['recurrence_end']);
         if ($group_id) {
             $data['group_id'] = $group_id;


### PR DESCRIPTION
## Summary
- enforce one-year limit for recurring events and normalize datetime format
- clear group references when deleting single events
- add UI filter to view all or only future events/reservations and fix datetime seconds

## Testing
- `php -l includes/admin/class-res-pong-admin-service.php`
- `php -l includes/admin/class-res-pong-admin-repository.php`


------
https://chatgpt.com/codex/tasks/task_e_689f3cd640008328a45642a8cbb07b6e