### PR TITLE
Add admin email page and translate UI to Italian

### DIFF
--- a/includes/admin/class-res-pong-admin-controller.php
+++ b/includes/admin/class-res-pong-admin-controller.php
@@ -209,6 +209,14 @@ class Res_Pong_Admin_Controller {
             },
         ]);
 
+        register_rest_route($namespace, '/email', [
+            'methods' => 'POST',
+            'callback' => [$this->service, 'rest_send_email'],
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        ]);
+
     }
 
 }

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -20,13 +20,14 @@ class Res_Pong_Admin_Frontend {
 
     public function register_menu() {
         add_menu_page('Res Pong', 'Res Pong', 'manage_options', 'res-pong-users', [ $this, 'render_users_page' ], 'dashicons-table-row-after');
-        add_submenu_page('res-pong-users', 'Users', 'Users', 'manage_options', 'res-pong-users', [ $this, 'render_users_page' ]);
-        add_submenu_page('res-pong-users', 'Events', 'Events', 'manage_options', 'res-pong-events', [ $this, 'render_events_page' ]);
-        add_submenu_page('res-pong-users', 'Reservations', 'Reservations', 'manage_options', 'res-pong-reservations', [ $this, 'render_reservations_page' ]);
-        add_submenu_page('res-pong-users', 'Configurations', 'Configurations', 'manage_options', 'res-pong-configurations', [ $this, 'render_configurations_page' ]);
-        add_submenu_page(null, 'User Detail', 'User Detail', 'manage_options', 'res-pong-user-detail', [ $this, 'render_user_detail' ]);
-        add_submenu_page(null, 'Event Detail', 'Event Detail', 'manage_options', 'res-pong-event-detail', [ $this, 'render_event_detail' ]);
-        add_submenu_page(null, 'Reservation Detail', 'Reservation Detail', 'manage_options', 'res-pong-reservation-detail', [ $this, 'render_reservation_detail' ]);
+        add_submenu_page('res-pong-users', 'Utenti', 'Utenti', 'manage_options', 'res-pong-users', [ $this, 'render_users_page' ]);
+        add_submenu_page('res-pong-users', 'Eventi', 'Eventi', 'manage_options', 'res-pong-events', [ $this, 'render_events_page' ]);
+        add_submenu_page('res-pong-users', 'Prenotazioni', 'Prenotazioni', 'manage_options', 'res-pong-reservations', [ $this, 'render_reservations_page' ]);
+        add_submenu_page('res-pong-users', 'Configurazioni', 'Configurazioni', 'manage_options', 'res-pong-configurations', [ $this, 'render_configurations_page' ]);
+        add_submenu_page('res-pong-users', 'Email', 'Email', 'manage_options', 'res-pong-email', [ $this, 'render_email_page' ]);
+        add_submenu_page(null, 'Dettaglio Utente', 'Dettaglio Utente', 'manage_options', 'res-pong-user-detail', [ $this, 'render_user_detail' ]);
+        add_submenu_page(null, 'Dettaglio Evento', 'Dettaglio Evento', 'manage_options', 'res-pong-event-detail', [ $this, 'render_event_detail' ]);
+        add_submenu_page(null, 'Dettaglio Prenotazione', 'Dettaglio Prenotazione', 'manage_options', 'res-pong-reservation-detail', [ $this, 'render_reservation_detail' ]);
     }
 
     public function enqueue_assets($hook) {
@@ -36,7 +37,8 @@ class Res_Pong_Admin_Frontend {
         wp_enqueue_style('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css');
         wp_enqueue_style('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/css/res-pong-admin.css', [], RES_PONG_VERSION);
         wp_enqueue_script('res-pong-datatables', 'https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js', [ 'jquery' ], null, true);
-        wp_enqueue_script('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/js/res-pong-admin.js', [ 'jquery', 'res-pong-datatables' ], RES_PONG_VERSION, true);
+        wp_enqueue_script('jquery-ui-autocomplete');
+        wp_enqueue_script('res-pong-admin', RES_PONG_PLUGIN_URL . 'assets/js/res-pong-admin.js', [ 'jquery', 'res-pong-datatables', 'jquery-ui-autocomplete' ], RES_PONG_VERSION, true);
         wp_localize_script('res-pong-admin', 'rp_admin', [
             'rest_url'  => esc_url_raw(rest_url('res-pong-admin/v1/')),
             'nonce'     => wp_create_nonce('wp_rest'),
@@ -47,7 +49,7 @@ class Res_Pong_Admin_Frontend {
     // List pages
     public function render_users_page() {
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . esc_html__('Users', 'res-pong') . '</h1>';
+        echo '<h1>' . esc_html__('Utenti', 'res-pong') . '</h1>';
         echo '<table id="res-pong-list" class="display" data-entity="users"></table>';
         $this->render_progress_overlay();
         echo '</div>';
@@ -55,7 +57,7 @@ class Res_Pong_Admin_Frontend {
 
     public function render_events_page() {
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . esc_html__('Events', 'res-pong') . '</h1>';
+        echo '<h1>' . esc_html__('Eventi', 'res-pong') . '</h1>';
         echo '<table id="res-pong-list" class="display" data-entity="events"></table>';
         $this->render_progress_overlay();
         echo '</div>';
@@ -63,9 +65,23 @@ class Res_Pong_Admin_Frontend {
 
     public function render_reservations_page() {
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . esc_html__('Reservations', 'res-pong') . '</h1>';
+        echo '<h1>' . esc_html__('Prenotazioni', 'res-pong') . '</h1>';
         echo '<table id="res-pong-list" class="display" data-entity="reservations"></table>';
         $this->render_progress_overlay();
+        echo '</div>';
+    }
+
+    public function render_email_page() {
+        echo '<div class="wrap rp-wrap">';
+        echo '<h1>Email</h1>';
+        echo '<form id="rp-email-form">';
+        echo '<table class="form-table">';
+        echo '<tr><th><label for="rp-email-to">Destinatari</label></th><td><input id="rp-email-to" type="text" class="large-text"></td></tr>';
+        echo '<tr><th><label for="rp-email-subject">Oggetto</label></th><td><input id="rp-email-subject" type="text" class="large-text"></td></tr>';
+        echo '<tr><th><label for="rp-email-text">Messaggio</label></th><td><textarea id="rp-email-text" rows="5" class="large-text" style="max-width:600px;min-height:10rem;"></textarea><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
+        echo '</table>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">Invia</button></p>';
+        echo '</form>';
         echo '</div>';
     }
 
@@ -84,28 +100,28 @@ class Res_Pong_Admin_Frontend {
                 'reset_password_text'      => isset($_POST['reset_password_text']) ? sanitize_textarea_field($_POST['reset_password_text']) : '',
             ];
             $this->configuration->update($data);
-            echo '<div class="updated"><p>' . esc_html__('Settings saved', 'res-pong') . '</p></div>';
+            echo '<div class="updated"><p>' . esc_html__('Impostazioni salvate', 'res-pong') . '</p></div>';
         }
         $config = $this->configuration->get_all();
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . esc_html__('Configurations', 'res-pong') . '</h1>';
+        echo '<h1>' . esc_html__('Configurazioni', 'res-pong') . '</h1>';
         echo '<form method="post">';
         wp_nonce_field('rp_save_configurations', 'rp_configurations_nonce');
         echo '<table class="form-table">';
-        echo '<tr><th><label for="almost_closed_minutes">Almost closed minutes</label></th><td><input name="almost_closed_minutes" id="almost_closed_minutes" type="number" value="' . esc_attr($config['almost_closed_minutes']) . '"></td></tr>';
-        echo '<tr><th><label for="almost_full_players">Almost full players</label></th><td><input name="almost_full_players" id="almost_full_players" type="number" value="' . esc_attr($config['almost_full_players']) . '"></td></tr>';
-        echo '<tr><th><label for="max_active_reservations">Max active reservations</label></th><td><input name="max_active_reservations" id="max_active_reservations" type="number" value="' . esc_attr($config['max_active_reservations']) . '"></td></tr>';
-        echo '<tr><th><label for="next_reservation_delay">Next reservation delay</label></th><td><input name="next_reservation_delay" id="next_reservation_delay" type="number" value="' . esc_attr($config['next_reservation_delay']) . '"></td></tr>';
-        echo '<tr><th colspan="2"><h2 style="margin: 0">First Access E-Mail</h2></th></tr>';
-        echo '<tr><th><label for="first_access_page_url">First access page URL</label></th><td><input name="first_access_page_url" id="first_access_page_url" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['first_access_page_url']) . '"></td></tr>';
-        echo '<tr><th><label for="invitation_subject">Invitation Subject</label></th><td><input name="invitation_subject" id="invitation_subject" type="text" class="large-text" style="max-width:600px;" value="' . esc_attr($config['invitation_subject']) . '"></td></tr>';
-        echo '<tr><th><label for="invitation_text">Invitation Text</label></th><td><textarea name="invitation_text" id="invitation_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['invitation_text']) . '</textarea></td></tr>';
-        echo '<tr><th colspan="2"><h2 style="margin: 0">Password Update E-Mail</h2></th></tr>';
-        echo '<tr><th><label for="password_update_page_url">Password update page URL</label></th><td><input name="password_update_page_url" id="password_update_page_url" style="max-width:600px;" class="large-text" type="text" value="' . esc_attr($config['password_update_page_url']) . '"></td></tr>';
-        echo '<tr><th><label for="reset_password_subject">Reset Password Subject</label></th><td><input name="reset_password_subject" id="reset_password_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['reset_password_subject']) . '"></td></tr>';
-        echo '<tr><th><label for="reset_password_text">Reset Password Text</label></th><td><textarea name="reset_password_text" id="reset_password_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['reset_password_text']) . '</textarea></td></tr>';
+        echo '<tr><th><label for="almost_closed_minutes">Minuti alla chiusura</label></th><td><input name="almost_closed_minutes" id="almost_closed_minutes" type="number" value="' . esc_attr($config['almost_closed_minutes']) . '"></td></tr>';
+        echo '<tr><th><label for="almost_full_players">Giocatori quasi completi</label></th><td><input name="almost_full_players" id="almost_full_players" type="number" value="' . esc_attr($config['almost_full_players']) . '"></td></tr>';
+        echo '<tr><th><label for="max_active_reservations">Max prenotazioni attive</label></th><td><input name="max_active_reservations" id="max_active_reservations" type="number" value="' . esc_attr($config['max_active_reservations']) . '"></td></tr>';
+        echo '<tr><th><label for="next_reservation_delay">Ritardo prossima prenotazione</label></th><td><input name="next_reservation_delay" id="next_reservation_delay" type="number" value="' . esc_attr($config['next_reservation_delay']) . '"></td></tr>';
+        echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail primo accesso</h2></th></tr>';
+        echo '<tr><th><label for="first_access_page_url">URL pagina primo accesso</label></th><td><input name="first_access_page_url" id="first_access_page_url" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['first_access_page_url']) . '"></td></tr>';
+        echo '<tr><th><label for="invitation_subject">Oggetto invito</label></th><td><input name="invitation_subject" id="invitation_subject" type="text" class="large-text" style="max-width:600px;" value="' . esc_attr($config['invitation_subject']) . '"></td></tr>';
+        echo '<tr><th><label for="invitation_text">Testo invito</label></th><td><textarea name="invitation_text" id="invitation_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['invitation_text']) . '</textarea></td></tr>';
+        echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail aggiornamento password</h2></th></tr>';
+        echo '<tr><th><label for="password_update_page_url">URL pagina aggiornamento password</label></th><td><input name="password_update_page_url" id="password_update_page_url" style="max-width:600px;" class="large-text" type="text" value="' . esc_attr($config['password_update_page_url']) . '"></td></tr>';
+        echo '<tr><th><label for="reset_password_subject">Oggetto reset password</label></th><td><input name="reset_password_subject" id="reset_password_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['reset_password_subject']) . '"></td></tr>';
+        echo '<tr><th><label for="reset_password_text">Testo reset password</label></th><td><textarea name="reset_password_text" id="reset_password_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['reset_password_text']) . '</textarea></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button></p>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva', 'res-pong') . '</button></p>';
         echo '</form>';
         echo '</div>';
     }
@@ -116,31 +132,31 @@ class Res_Pong_Admin_Frontend {
         $editing = !empty($id);
         $config = $this->configuration->get_all();
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . ($editing ? esc_html__('Edit User', 'res-pong') : esc_html__('Add User', 'res-pong')) . '</h1>';
+        echo '<h1>' . ($editing ? esc_html__('Modifica utente', 'res-pong') : esc_html__('Aggiungi utente', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="users" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
         echo '<tr><th><label for="id">ID</label></th><td><input name="id" id="id" type="text"' . ( $editing ? ' readonly' : '' ) . '></td></tr>';
         echo '<tr><th><label for="email">Email</label></th><td><input name="email" id="email" type="email"></td></tr>';
-        echo '<tr><th><label for="username">Username</label></th><td><input name="username" id="username" type="text"></td></tr>';
-        echo '<tr><th><label for="first_name">First Name</label></th><td><input name="first_name" id="first_name" type="text"></td></tr>';
-        echo '<tr><th><label for="last_name">Last Name</label></th><td><input name="last_name" id="last_name" type="text"></td></tr>';
-        echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
-        echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"' . ( $editing ? '' : ' checked' ) . '></td></tr>';
+        echo '<tr><th><label for="username">Nome utente</label></th><td><input name="username" id="username" type="text"></td></tr>';
+        echo '<tr><th><label for="first_name">Nome</label></th><td><input name="first_name" id="first_name" type="text"></td></tr>';
+        echo '<tr><th><label for="last_name">Cognome</label></th><td><input name="last_name" id="last_name" type="text"></td></tr>';
+        echo '<tr><th><label for="category">Categoria</label></th><td><input name="category" id="category" type="text"></td></tr>';
+        echo '<tr><th><label for="enabled">Abilitato</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"' . ( $editing ? '' : ' checked' ) . '></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva', 'res-pong') . '</button>';
         if ($editing) {
-            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Elimina', 'res-pong') . '</button>';
         }
         echo ' <button type="button" class="button" id="res-pong-impersonate"' . ( $editing ? '' : ' disabled' ) . '>' . esc_html__('Impersona', 'res-pong') . '</button>';
-        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-users')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
+        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-users')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Indietro', 'res-pong') . '</a>';
         echo '</p></form>';
-        echo '<h2>' . esc_html__('Password Reset', 'res-pong') . '</h2>';
+        echo '<h2>' . esc_html__('Reset password', 'res-pong') . '</h2>';
         echo '<form id="res-pong-password-form" data-entity="users" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
-        echo '<tr><th><label for="new_password">New Password</label></th><td><input name="new_password" id="new_password" type="password"></td></tr>';
-        echo '<tr><th><label for="confirm_password">Confirm Password</label></th><td><input name="confirm_password" id="confirm_password" type="password"></td></tr>';
+        echo '<tr><th><label for="new_password">Nuova password</label></th><td><input name="new_password" id="new_password" type="password"></td></tr>';
+        echo '<tr><th><label for="confirm_password">Conferma password</label></th><td><input name="confirm_password" id="confirm_password" type="password"></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save Password', 'res-pong') . '</button></p>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva password', 'res-pong') . '</button></p>';
         echo '</form>';
         echo '<div id="rp-invite-wrapper" style="display:none;">';
         echo '<h2>' . esc_html__('Invia Messaggio di Invito', 'res-pong') . '</h2>';
@@ -150,7 +166,7 @@ class Res_Pong_Admin_Frontend {
         echo '<p><button type="button" class="button button-primary" id="rp-send-invite">' . esc_html__('Invia', 'res-pong') . '</button></p>';
         echo '</div>';
         echo '<div id="rp-reset-wrapper" style="display:none;">';
-        echo '<h2>' . esc_html__('Send Password Reset Link', 'res-pong') . '</h2>';
+        echo '<h2>' . esc_html__('Invia link di reset password', 'res-pong') . '</h2>';
         echo '<p><input type="text" readonly class="large-text" style="max-width: 600px;" id="rp-reset-subject" value="' . esc_attr($config['reset_password_subject']) . '"></p>';
         echo '<p style=" margin-bottom: 0;"><textarea id="rp-reset-text" rows="5" class="large-text" style="max-width:600px;min-height:10rem;">' . esc_textarea($config['reset_password_text']) . '</textarea></p>';
         echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p>';
@@ -162,9 +178,9 @@ class Res_Pong_Admin_Frontend {
         echo '<table class="form-table">';
         echo '<tr><th><label for="timeout">Timeout</label></th><td><input name="timeout" id="timeout" type="datetime-local" step="1" value="' . esc_attr($default_timeout) . '"></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save Timeout', 'res-pong') . '</button></p>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva timeout', 'res-pong') . '</button></p>';
         echo '</form>';
-        echo '<h2>' . esc_html__('User Reservations', 'res-pong') . '</h2>';
+        echo '<h2>' . esc_html__('Prenotazioni utente', 'res-pong') . '</h2>';
         echo '<table id="res-pong-user-reservations" class="display" data-user="' . esc_attr($id) . '"></table>';
         $this->render_progress_overlay();
         echo '</div>';
@@ -176,27 +192,30 @@ class Res_Pong_Admin_Frontend {
         $default_start = date('Y-m-d\\T21:30:00');
         $default_end = date('Y-m-d\\T23:00:00');
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . ($editing ? esc_html__('Edit Event', 'res-pong') : esc_html__('Add Event', 'res-pong')) . '</h1>';
+        echo '<h1>' . ($editing ? esc_html__('Modifica evento', 'res-pong') : esc_html__('Aggiungi evento', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="events" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
-        echo '<tr><th><label for="group_id">Group ID</label></th><td><select name="group_id" id="group_id"></select></td></tr>';
+        echo '<tr><th><label for="group_id">ID gruppo</label></th><td><select name="group_id" id="group_id"></select></td></tr>';
         echo '<tr id="recurrence_row"><th><label for="recurrence">Ricorrenza</label></th><td><select name="recurrence" id="recurrence"><option value="none">Mai</option><option value="daily">Giornaliera</option><option value="weekly">Settimanale</option><option value="monthly">Mensile</option></select></td></tr>';
         echo '<tr id="recurrence_end_row"><th><label for="recurrence_end">Termine ricorrenza</label></th><td><input name="recurrence_end" id="recurrence_end" type="date" disabled></td></tr>';
-        echo '<tr><th><label for="category">Category</label></th><td><input name="category" id="category" type="text"></td></tr>';
-        echo '<tr><th><label for="name">Name</label></th><td><input name="name" id="name" type="text"></td></tr>';
-        echo '<tr><th><label for="note">Note</label></th><td><textarea name="note" id="note"></textarea></td></tr>';
-        echo '<tr><th><label for="start_datetime">Start</label></th><td><input name="start_datetime" id="start_datetime" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_start) . '"' ) . '></td></tr>';
-        echo '<tr><th><label for="end_datetime">End</label></th><td><input name="end_datetime" id="end_datetime" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_end) . '"' ) . '></td></tr>';
-        echo '<tr><th><label for="max_players">Max Players</label></th><td><input name="max_players" id="max_players" type="number"></td></tr>';
-        echo '<tr><th><label for="enabled">Enabled</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"' . ( $editing ? '' : ' checked' ) . '></td></tr>';
+        echo '<tr><th><label for="category">Categoria</label></th><td><input name="category" id="category" type="text"></td></tr>';
+        echo '<tr><th><label for="name">Nome</label></th><td><input name="name" id="name" type="text"></td></tr>';
+        echo '<tr><th><label for="note">Nota</label></th><td><textarea name="note" id="note"></textarea></td></tr>';
+        echo '<tr><th><label for="start_datetime">Inizio</label></th><td><input name="start_datetime" id="start_datetime" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_start) . '"' ) . '></td></tr>';
+        echo '<tr><th><label for="end_datetime">Fine</label></th><td><input name="end_datetime" id="end_datetime" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_end) . '"' ) . '></td></tr>';
+        echo '<tr><th><label for="max_players">Giocatori max</label></th><td><input name="max_players" id="max_players" type="number"></td></tr>';
+        echo '<tr><th><label for="enabled">Abilitato</label></th><td><input name="enabled" id="enabled" type="checkbox" value="1"' . ( $editing ? '' : ' checked' ) . '></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva', 'res-pong') . '</button>';
         if ($editing) {
-            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Elimina', 'res-pong') . '</button>';
         }
-        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-events')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
+        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-events')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Indietro', 'res-pong') . '</a>';
         echo '</p></form>';
-        echo '<h2>' . esc_html__('Event Reservations', 'res-pong') . '</h2>';
+        if ($editing) {
+            echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=res-pong-email&event_id=' . $id)) . '">Contatta i partecipanti</a></p>';
+        }
+        echo '<h2>' . esc_html__('Prenotazioni evento', 'res-pong') . '</h2>';
         echo '<table id="res-pong-event-reservations" class="display" data-event="' . esc_attr($id) . '"></table>';
         $this->render_progress_overlay();
         echo '</div>';
@@ -207,19 +226,19 @@ class Res_Pong_Admin_Frontend {
         $editing = !empty($id);
         $default_created = date('Y-m-d\\TH:i:s');
         echo '<div class="wrap rp-wrap">';
-        echo '<h1>' . ($editing ? esc_html__('Edit Reservation', 'res-pong') : esc_html__('Add Reservation', 'res-pong')) . '</h1>';
+        echo '<h1>' . ($editing ? esc_html__('Modifica prenotazione', 'res-pong') : esc_html__('Aggiungi prenotazione', 'res-pong')) . '</h1>';
         echo '<form id="res-pong-detail-form" data-entity="reservations" data-id="' . esc_attr($id) . '">';
         echo '<table class="form-table">';
-        echo '<tr><th><label for="user_id">User ID</label></th><td><select name="user_id" id="user_id"></select></td></tr>';
-        echo '<tr><th><label for="event_id">Event ID</label></th><td><select name="event_id" id="event_id"></select></td></tr>';
-        echo '<tr><th><label for="created_at">Created At</label></th><td><input name="created_at" id="created_at" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_created) . '"' ) . '></td></tr>';
-        echo '<tr><th><label for="presence_confirmed">Presence Confirmed</label></th><td><input name="presence_confirmed" id="presence_confirmed" type="checkbox" value="1"></td></tr>';
+        echo '<tr><th><label for="user_id">ID utente</label></th><td><select name="user_id" id="user_id"></select></td></tr>';
+        echo '<tr><th><label for="event_id">ID evento</label></th><td><select name="event_id" id="event_id"></select></td></tr>';
+        echo '<tr><th><label for="created_at">Creato il</label></th><td><input name="created_at" id="created_at" type="datetime-local" step="1"' . ( $editing ? '' : ' value="' . esc_attr($default_created) . '"' ) . '></td></tr>';
+        echo '<tr><th><label for="presence_confirmed">Presenza confermata</label></th><td><input name="presence_confirmed" id="presence_confirmed" type="checkbox" value="1"></td></tr>';
         echo '</table>';
-        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Save', 'res-pong') . '</button>';
+        echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva', 'res-pong') . '</button>';
         if ($editing) {
-            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Delete', 'res-pong') . '</button>';
+            echo ' <button type="button" class="button rp-button-danger" id="res-pong-delete">' . esc_html__('Elimina', 'res-pong') . '</button>';
         }
-        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-reservations')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Back', 'res-pong') . '</a>';
+        echo ' <a href="' . esc_url(admin_url('admin.php?page=res-pong-reservations')) . '" class="button button-secondary" id="res-pong-back">' . esc_html__('Indietro', 'res-pong') . '</a>';
         echo '</p></form>';
         $this->render_progress_overlay();
         echo '</div>';

--- a/includes/admin/class-res-pong-admin-repository.php
+++ b/includes/admin/class-res-pong-admin-repository.php
@@ -86,6 +86,11 @@ class Res_Pong_Admin_Repository {
         return $this->wpdb->get_row($this->wpdb->prepare($sql, $id), ARRAY_A);
     }
 
+    public function find_user_by_email($email) {
+        $sql = "SELECT *, CONCAT(last_name, ' ', first_name) AS name FROM {$this->table_user} WHERE email = %s";
+        return $this->wpdb->get_row($this->wpdb->prepare($sql, $email), ARRAY_A);
+    }
+
     public function insert_user($data) {
         return $this->wpdb->insert($this->table_user, $data);
     }
@@ -158,7 +163,7 @@ class Res_Pong_Admin_Repository {
             $params[] = current_time('mysql');
         }
         $where_sql = $where ? 'WHERE ' . implode(' AND ', $where) : '';
-        $sql = "SELECT r.*, u.username, CONCAT(u.last_name, ' ', u.first_name) AS name, e.name AS event_name, e.start_datetime AS event_start_datetime FROM {$this->table_reservation} r JOIN {$this->table_user} u ON r.user_id = u.id JOIN {$this->table_event} e ON r.event_id = e.id {$where_sql} ORDER BY r.created_at DESC";
+        $sql = "SELECT r.*, u.username, u.email, CONCAT(u.last_name, ' ', u.first_name) AS name, e.name AS event_name, e.start_datetime AS event_start_datetime FROM {$this->table_reservation} r JOIN {$this->table_user} u ON r.user_id = u.id JOIN {$this->table_event} e ON r.event_id = e.id {$where_sql} ORDER BY r.created_at DESC";
         if ($params) {
             $sql = $this->wpdb->prepare($sql, $params);
         }


### PR DESCRIPTION
## Summary
- translate admin UI labels to Italian and add contact participants link
- add email sending page with user suggestions and placeholder support
- display inline success/error messages for admin forms and validate required user fields

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `php -l includes/admin/class-res-pong-admin-controller.php`
- `php -l includes/admin/class-res-pong-admin-repository.php`
- `php -l includes/admin/class-res-pong-admin-service.php`


------
https://chatgpt.com/codex/tasks/task_e_689f41fb2f308328a737b99874d030fe