### PR TITLE
Skip duplicate user fields on import and fix email autocomplete

### DIFF
--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -343,7 +343,20 @@
                     contentType: false,
                     beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
                     complete: function(){ hideOverlay(); input.remove(); },
-                    success: function(){ dt.ajax.reload(); showNotice('success', 'Importazione Completata'); },
+                    success: function(res){
+                        dt.ajax.reload();
+                        var msg = 'Importazione completata';
+                        if(res && res.skipped && res.skipped.length){
+                            msg += '. Utenti scartati: ' + res.skipped.map(function(u){
+                                var base = u.email || u.id || 'n/a';
+                                if(u.reasons && u.reasons.length){
+                                    return base + ' (' + u.reasons.join(', ') + ')';
+                                }
+                                return base;
+                            }).join(', ');
+                        }
+                        showNotice('success', msg);
+                    },
                     error: function(xhr){
                         var msg = 'Importazione fallita';
                         if(xhr.responseJSON && xhr.responseJSON.message){ msg += ': ' + xhr.responseJSON.message; }
@@ -742,7 +755,7 @@
                 });
                 toInput.autocomplete({
                     source: function(request, response){
-                        var term = request.term.toLowerCase();
+                        var term = request.term.toLowerCase().split(/,\s*/).pop();
                         response(items.filter(function(it){ return it.search.indexOf(term) !== -1; }));
                     },
                     minLength: 0,

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -82,6 +82,7 @@ class Res_Pong_Admin_Frontend {
         echo '<tr><th></th><td><button type="submit" class="button button-primary">Invia</button></td></tr>';
         echo '</table>';
         echo '</form>';
+        $this->render_progress_overlay();
         echo '</div>';
     }
 

--- a/includes/admin/class-res-pong-admin-service.php
+++ b/includes/admin/class-res-pong-admin-service.php
@@ -333,10 +333,11 @@ class Res_Pong_Admin_Service {
         if (is_wp_error($result)) {
             return $result;
         }
-        if (!$result) {
+        if ($result === false) {
             return new WP_Error('import_failed', 'Importazione utenti fallita', ['status' => 500]);
         }
-        return new WP_REST_Response(['success' => true], 200);
+        $skipped = is_array($result) ? $result : [];
+        return new WP_REST_Response(['success' => true, 'skipped' => $skipped], 200);
     }
 
     public function rest_export_events() {


### PR DESCRIPTION
## Summary
- Skip CSV user rows when tessera, email or generated username already exist, comparing username and email in lowercase
- Display progress overlay on email send page and keep recipient suggestions after a selection

## Testing
- `php -l includes/admin/class-res-pong-admin-repository.php`
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `php -l includes/admin/class-res-pong-admin-service.php`


------
https://chatgpt.com/codex/tasks/task_e_689f57362fe883289f7247dd12eb6924