### PR TITLE
feat: enhance import feedback and add wp-dist packaging

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "watch": "ng build --watch --configuration development"
+    "watch": "ng build --watch --configuration development",
+    "wp-dist": "node ./scripts/wp-dist.js"
   },
   "private": true,
   "dependencies": {

--- a/app/scripts/wp-dist.js
+++ b/app/scripts/wp-dist.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+const {execSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function titleCase(str){
+    return str.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function pad(n){
+    return String(n).padStart(2, '0');
+}
+
+(function(){
+    const appDir = path.resolve(__dirname, '..');
+    const rootDir = path.resolve(appDir, '..');
+    const pkg = require(path.join(appDir, 'package.json'));
+    const name = pkg.name;
+    const version = pkg.version;
+    const pluginName = titleCase(name);
+
+    execSync('npx ng build --configuration production', {cwd: appDir, stdio: 'inherit'});
+
+    const pluginFile = path.join(rootDir, 'res-pong.php');
+    let content = fs.readFileSync(pluginFile, 'utf8');
+    content = content.replace(/(\* Plugin Name:\s*).*/, `$1${pluginName}`);
+    content = content.replace(/(\* Version:\s*).*/, `$1${version}`);
+    content = content.replace(/(define\('RES_PONG_VERSION',\s*RES_PONG_DEV \? time\(\) : ')[^']+('\);)/, `$1${version}$2`);
+    fs.writeFileSync(pluginFile, content);
+
+    const releaseDir = path.join(rootDir, 'release');
+    const tempDir = path.join(releaseDir, 'temp');
+    fs.mkdirSync(releaseDir, {recursive: true});
+    fs.rmSync(tempDir, {recursive: true, force: true});
+    fs.mkdirSync(tempDir);
+
+    const copy = (src, dest) => fs.cpSync(src, dest, {recursive: true});
+    copy(path.join(rootDir, 'assets'), path.join(tempDir, 'assets'));
+    copy(path.join(rootDir, 'includes'), path.join(tempDir, 'includes'));
+
+    ['README.md', 'res-pong.php', 'uninstall.php'].forEach(file => {
+        fs.copyFileSync(path.join(rootDir, file), path.join(tempDir, file));
+    });
+
+    const distDir = path.join(appDir, 'dist', 'browser');
+    const destAppDir = path.join(tempDir, 'app');
+    fs.mkdirSync(destAppDir);
+    copy(distDir, destAppDir);
+
+    const finalDir = path.join(releaseDir, 'res-pong');
+    fs.rmSync(finalDir, {recursive: true, force: true});
+    fs.renameSync(tempDir, finalDir);
+
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${pad(now.getMonth()+1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}`;
+    const zipName = `${name}-${version}-${dateStr}.zip`;
+    execSync(`zip -r ${zipName} res-pong`, {cwd: releaseDir, stdio: 'inherit'});
+})();

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -347,13 +347,14 @@
                         dt.ajax.reload();
                         var msg = 'Importazione completata';
                         if(res && res.skipped && res.skipped.length){
-                            msg += '. Utenti scartati: ' + res.skipped.map(function(u){
+                            msg += '<br>Utenti scartati:';
+                            res.skipped.forEach(function(u){
                                 var base = u.email || u.id || 'n/a';
                                 if(u.reasons && u.reasons.length){
-                                    return base + ' (' + u.reasons.join(', ') + ')';
+                                    base += ' (' + u.reasons.join(', ') + ')';
                                 }
-                                return base;
-                            }).join(', ');
+                                msg += '<br>' + base;
+                            });
                         }
                         showNotice('success', msg);
                     },


### PR DESCRIPTION
## Summary
- list discarded users with reasons after CSV import
- add `wp-dist` script to build and package plugin

## Testing
- `node app/scripts/wp-dist.js` *(fails: Inlining of fonts failed)*
- `npm --prefix app test` *(fails: Missing script "test")*
- `php -l res-pong.php`


------
https://chatgpt.com/codex/tasks/task_e_689f613ee85883288f824441d1542c41