### PR TITLE
Show all reservations in admin event detail

### DIFF
--- a/includes/admin/class-res-pong-admin-service.php
+++ b/includes/admin/class-res-pong-admin-service.php
@@ -183,7 +183,11 @@ class Res_Pong_Admin_Service {
         $user_id = $request->get_param('user_id');
         $event_id = $request->get_param('event_id');
         $active_only = $request->get_param('active_only');
-        $active_only = is_null($active_only) ? true : (bool)intval($active_only);
+        if (is_null($active_only)) {
+            $active_only = is_null($event_id) ? true : false;
+        } else {
+            $active_only = (bool)intval($active_only);
+        }
         return rest_ensure_response($this->repository->get_reservations($user_id, $event_id, $active_only));
     }
 


### PR DESCRIPTION
## Summary
- Ensure event detail returns every reservation for an event instead of filtering to upcoming ones

## Testing
- `php -l includes/admin/class-res-pong-admin-service.php`
- `npm run build` *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Inter:wght@300..800&display=swap returned status code: 403.)*

------
https://chatgpt.com/codex/tasks/task_e_689f68490ef08328b0b6fab7e35b8c97