### PR TITLE
feat: use Node archiver for release script

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "@angular-devkit/build-angular": "^19.2.15",
     "@angular/cli": "^19.2.11",
     "@angular/compiler-cli": "^19.2.0",
+    "archiver": "^5.3.2",
     "typescript": "~5.7.2"
   }
 }


### PR DESCRIPTION
## Summary
- add archiver dev dependency
- switch wp-dist build script to Node archiver API for zipping with async error handling

## Testing
- `npm install archiver --save-dev` *(fails: 403 Forbidden)*
- `npm run wp-dist` *(fails: Cannot find module 'archiver')*


------
https://chatgpt.com/codex/tasks/task_e_689f68f44b788328ac5df7d54b094900