### PR TITLE
Set RES_PONG_DEV to false in release build

### DIFF
--- a/app/scripts/wp-dist.js
+++ b/app/scripts/wp-dist.js
@@ -41,7 +41,14 @@ function pad(n) {
     copy(path.join(rootDir, 'includes'), path.join(tempDir, 'includes'));
 
     ['README.md', 'res-pong.php', 'uninstall.php'].forEach(file => {
-      fs.copyFileSync(path.join(rootDir, file), path.join(tempDir, file));
+      const src = path.join(rootDir, file);
+      const dest = path.join(tempDir, file);
+      fs.copyFileSync(src, dest);
+      if (file === 'res-pong.php') {
+        let releaseContent = fs.readFileSync(dest, 'utf8');
+        releaseContent = releaseContent.replace('define(\'RES_PONG_DEV\', true);', 'define(\'RES_PONG_DEV\', false);');
+        fs.writeFileSync(dest, releaseContent);
+      }
     });
 
     const distDir = path.join(appDir, 'dist', 'browser');


### PR DESCRIPTION
## Summary
- Ensure build script sets `RES_PONG_DEV` to false in the copied `res-pong.php` when packaging a release

## Testing
- `php -l res-pong.php`
- `npm run wp-dist` *(fails: Inlining of fonts failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e6497bc8328854b8676aa9c439b