### PR TITLE
Add reinitialize option on configurations page

### DIFF
--- a/includes/admin/class-res-pong-admin-repository.php
+++ b/includes/admin/class-res-pong-admin-repository.php
@@ -74,6 +74,12 @@ class Res_Pong_Admin_Repository {
         dbDelta($sql);
     }
 
+    public function drop_tables() {
+        $this->wpdb->query("DROP TABLE IF EXISTS {$this->table_reservation}");
+        $this->wpdb->query("DROP TABLE IF EXISTS {$this->table_event}");
+        $this->wpdb->query("DROP TABLE IF EXISTS {$this->table_user}");
+    }
+
     // ------------------------
     // RP_USER methods
     // ------------------------


### PR DESCRIPTION
## Summary
- add drop_tables helper in admin repository
- allow admin to reset plugin tables and options via new configurations-page block

## Testing
- `php -l includes/admin/class-res-pong-admin-repository.php`
- `php -l includes/admin/class-res-pong-admin-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_68a071c27f34832887e616472408e34c