### PR TITLE
Replace browser confirm with custom dialog

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -159,3 +159,30 @@ button.rp-unsign,
     white-space: nowrap;
     margin-top: 0;
 }
+
+.rp-confirm-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100001;
+}
+
+.rp-confirm-dialog {
+    background: #fff;
+    padding: 20px;
+    text-align: center;
+    border-radius: 4px;
+}
+
+.rp-confirm-buttons {
+    margin-top: 15px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -49,7 +49,22 @@
         btn.after(notice);
     }
     function rpConfirm(message){
-        return Promise.resolve(window.confirm(message));
+        if(typeof window.jQuery === 'undefined'){
+            return Promise.resolve(window.confirm(message));
+        }
+        return new Promise(function(resolve){
+            var overlay = $('<div class="rp-confirm-overlay"></div>').appendTo('body');
+            var dialog = $('<div class="rp-confirm-dialog"><p></p><div class="rp-confirm-buttons"><button class="button button-primary rp-confirm-yes">Si</button><button class="button rp-confirm-no">No</button></div></div>').appendTo(overlay);
+            dialog.find('p').text(message);
+            overlay.on('click', '.rp-confirm-yes', function(){
+                overlay.remove();
+                resolve(true);
+            });
+            overlay.on('click', '.rp-confirm-no', function(){
+                overlay.remove();
+                resolve(false);
+            });
+        });
     }
     function restUrl(path, params){
         var url = rp_admin.rest_url + path;


### PR DESCRIPTION
## Summary
- replace native `confirm` with custom jQuery dialog using **Si**/**No** buttons
- add styles for new confirmation overlay and dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c210a7148328935bad96caac58b1