### PR TITLE
chore: update build script with environment metadata

### DIFF
--- a/app/scripts/wp-dist.js
+++ b/app/scripts/wp-dist.js
@@ -21,6 +21,14 @@ function pad(n) {
     const version = pkg.version;
     const pluginName = titleCase(name);
 
+    const envFile = path.join(appDir, 'src', 'environments', 'environment.ts');
+    let envContent = fs.readFileSync(envFile, 'utf8');
+    const buildDate = new Date();
+    const buildStr = `${buildDate.getFullYear()}${pad(buildDate.getMonth() + 1)}${pad(buildDate.getDate())}${pad(buildDate.getHours())}${pad(buildDate.getMinutes())}${pad(buildDate.getSeconds())}`;
+    envContent = envContent.replace(/(version:\s*')[^']+(')/, `$1${version}$2`);
+    envContent = envContent.replace(/(build:\s*')[^']+(')/, `$1${buildStr}$2`);
+    fs.writeFileSync(envFile, envContent);
+
     execSync('npx ng build --configuration production', {cwd: appDir, stdio: 'inherit'});
 
     const pluginFile = path.join(rootDir, 'res-pong.php');


### PR DESCRIPTION
## Summary
- update wp-dist.js to write version from package.json and build timestamp into environment.ts before running Angular build

## Testing
- `node app/scripts/wp-dist.js` *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Inter:wght@300..800&display=swap returned status code: 403.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1752979948328884e9c3a4a850b26