### PR TITLE
Use guard table to avoid concurrent reservations

### DIFF
--- a/includes/user/class-res-pong-user-repository.php
+++ b/includes/user/class-res-pong-user-repository.php
@@ -4,6 +4,7 @@ class Res_Pong_User_Repository {
     private $table_user;
     private $table_event;
     private $table_reservation;
+    private $table_guard;
     private $wpdb;
 
     public function __construct() {
@@ -13,6 +14,7 @@ class Res_Pong_User_Repository {
         $this->table_user = $prefix . 'RP_USER';
         $this->table_event = $prefix . 'RP_EVENT';
         $this->table_reservation = $prefix . 'RP_RESERVATION';
+        $this->table_guard = $prefix . 'RP_GUARD';
     }
 
     public function get_user_by_id($id) {
@@ -41,6 +43,16 @@ class Res_Pong_User_Repository {
 
     public function insert_reservation($data) {
         return $this->wpdb->insert($this->table_reservation, $data);
+    }
+
+    public function acquire_guard($user_id, $group_id) {
+        $sql = $this->wpdb->prepare("INSERT INTO {$this->table_guard} (user_id, group_id) VALUES (%s, %d)", $user_id, $group_id);
+        $this->wpdb->query($sql);
+    }
+
+    public function release_guard($user_id, $group_id) {
+        $sql = $this->wpdb->prepare("DELETE FROM {$this->table_guard} WHERE user_id = %s AND group_id = %d", $user_id, $group_id);
+        $this->wpdb->query($sql);
     }
 
     public function get_reservations_by_user_id($user_id) {


### PR DESCRIPTION
## Summary
- Wrap user reservation creation in a transaction and use guard rows to lock on group_id
- Add guard table helpers in repository for acquiring and releasing locks

## Testing
- `php -l includes/user/class-res-pong-user-service.php`
- `php -l includes/user/class-res-pong-user-repository.php` *(deprecated warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cf549a948328b7bff397e5cc55a7