### PR TITLE
feat: add simple tutorial overlay

### DIFF
--- a/app/src/app/app.component.html
+++ b/app/src/app/app.component.html
@@ -1,4 +1,5 @@
 <res-pong-user-menu></res-pong-user-menu>
+<res-pong-user-tutorial></res-pong-user-tutorial>
 <div class="rp-content">
   <router-outlet/>
 </div>

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -3,11 +3,12 @@ import {RouterOutlet} from '@angular/router';
 import {MenuModule} from 'primeng/menu';
 import {Divider} from 'primeng/divider';
 import {MenuComponent} from '../components/menu/menu.component';
+import {TutorialComponent} from '../components/tutorial/tutorial.component';
 import {environment} from '../environments/environment';
 
 @Component({
   selector: 'res-pong-user-root',
-  imports: [RouterOutlet, MenuComponent, MenuModule, Divider],
+  imports: [RouterOutlet, MenuComponent, MenuModule, Divider, TutorialComponent],
   templateUrl: './app.component.html',
   encapsulation: ViewEncapsulation.Emulated,
   styleUrl: './app.component.scss'

--- a/app/src/components/menu/menu.component.ts
+++ b/app/src/components/menu/menu.component.ts
@@ -4,6 +4,7 @@ import {MenuItem, MenuItemCommandEvent} from 'primeng/api';
 import {Avatar} from 'primeng/avatar';
 import {MenuModule} from 'primeng/menu';
 import {ResPongService} from '../../service/res-pong.service';
+import {TutorialService} from '../../service/tutorial.service';
 import {Observable} from 'rxjs';
 import {AsyncPipe, NgIf} from '@angular/common';
 import {Button} from 'primeng/button';
@@ -31,6 +32,7 @@ import {ProgressSpinner} from 'primeng/progressspinner';
 export class MenuComponent {
   private resPongService = inject(ResPongService);
   private router = inject(Router);
+  private tutorial = inject(TutorialService);
 
   loggingOut = false;
 
@@ -128,6 +130,6 @@ export class MenuComponent {
   }
 
   help() {
-    // todo qui fa partire il tutorial per la pagina corrente
+    this.tutorial.startForUrl(this.router.url);
   }
 }

--- a/app/src/components/tutorial/tutorial.component.html
+++ b/app/src/components/tutorial/tutorial.component.html
@@ -1,0 +1,8 @@
+<p-popover #popover [dismissable]="false" appendTo="body">
+  <div class="tutorial-text">{{ state?.step?.text }}</div>
+  <div class="tutorial-actions">
+    <a (click)="next()">Avanti</a>
+    <a (click)="end()">Chiudi Tutorial</a>
+  </div>
+</p-popover>
+<div class="tutorial-overlay" *ngIf="state"></div>

--- a/app/src/components/tutorial/tutorial.component.scss
+++ b/app/src/components/tutorial/tutorial.component.scss
@@ -1,0 +1,27 @@
+.tutorial-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+}
+
+.tutorial-actions {
+  margin-top: 0.5rem;
+  text-align: right;
+}
+
+.tutorial-actions a {
+  margin-left: 1rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.tutorial-highlight {
+  z-index: 1002;
+  position: relative;
+  box-shadow: 0 0 0 3px #ffffff;
+  pointer-events: none;
+}

--- a/app/src/components/tutorial/tutorial.component.ts
+++ b/app/src/components/tutorial/tutorial.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { Popover, PopoverModule } from 'primeng/popover';
+import { TutorialService, TutorialState } from '../../service/tutorial.service';
+
+@Component({
+    selector: 'res-pong-user-tutorial',
+    standalone: true,
+    imports: [NgIf, PopoverModule],
+    templateUrl: './tutorial.component.html',
+    styleUrl: './tutorial.component.scss'
+})
+export class TutorialComponent implements OnInit, OnDestroy {
+    private tutorial = inject(TutorialService);
+    state: TutorialState | null = null;
+    private sub: any;
+    @ViewChild('popover') popover?: Popover;
+
+    ngOnInit(): void {
+        this.sub = this.tutorial.tutorial$.subscribe(state => {
+            this.popover?.hide();
+            this.removeHighlight();
+            this.state = state;
+            if (state) {
+                const el = document.querySelector(state.step.selector) as HTMLElement | null;
+                if (el) {
+                    el.classList.add('tutorial-highlight');
+                    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    setTimeout(() => this.popover?.show(null, el));
+                } else {
+                    setTimeout(() => this.popover?.show(null));
+                }
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.sub?.unsubscribe();
+        this.removeHighlight();
+    }
+
+    next(): void {
+        this.tutorial.next();
+    }
+
+    end(): void {
+        this.tutorial.end();
+        this.popover?.hide();
+    }
+
+    private removeHighlight(): void {
+        if (this.state) {
+            const el = document.querySelector(this.state.step.selector) as HTMLElement | null;
+            el?.classList.remove('tutorial-highlight');
+        }
+    }
+}
+

--- a/app/src/pages/reservations/reservations.component.ts
+++ b/app/src/pages/reservations/reservations.component.ts
@@ -9,6 +9,7 @@ import {TimelineComponent} from '../../components/timeline/timeline.component';
 import {Common} from '../../util/common';
 import {of, Subject} from 'rxjs';
 import {catchError, debounceTime, distinctUntilChanged, map, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {TutorialService, TutorialStep} from '../../service/tutorial.service';
 
 @Component({
   selector: 'res-pong-user-reservations',
@@ -28,6 +29,7 @@ export class ReservationsComponent implements OnInit, OnDestroy {
   private activatedRoute = inject(ActivatedRoute);
   private resPongService = inject(ResPongService);
   private router = inject(Router);
+  private tutorial = inject(TutorialService);
 
   private destroy$ = new Subject<void>();
 
@@ -38,8 +40,13 @@ export class ReservationsComponent implements OnInit, OnDestroy {
   mode: 'calendar' | 'timeline' = (localStorage.getItem('res_pong_reservation_view_mode') || 'timeline') as 'calendar' | 'timeline';
   events: any = undefined;
   subTitle: string = '•••';
+  private tutorialSteps: TutorialStep[] = [
+    {selector: '.rp-reservations-title-box', text: 'In questa sezione trovi il mese corrente.'},
+    {selector: '.rp-calendar-legend', text: 'Qui trovi la legenda delle disponibilità.'}
+  ];
 
   ngOnInit(): void {
+    this.tutorial.register('/reservations', this.tutorialSteps);
     this.activatedRoute.paramMap.pipe(
       map(params => params.has('index') ? Number(params.get('index')) : Common.getMonthIndexFromDate()),
       tap(ptr => {

--- a/app/src/service/tutorial.service.ts
+++ b/app/src/service/tutorial.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+export interface TutorialStep {
+    selector: string;
+    text: string;
+}
+
+export interface TutorialState {
+    step: TutorialStep;
+    index: number;
+    total: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TutorialService {
+    private tutorials = new Map<string, TutorialStep[]>();
+    private steps: TutorialStep[] = [];
+    private index = 0;
+    private state$ = new BehaviorSubject<TutorialState | null>(null);
+
+    register(path: string, steps: TutorialStep[]): void {
+        this.tutorials.set(path, steps);
+    }
+
+    startForUrl(url: string): void {
+        const match = Array.from(this.tutorials.keys()).find(p => url.startsWith(p));
+        if (match) {
+            this.start(match);
+        }
+    }
+
+    private start(path: string): void {
+        this.steps = this.tutorials.get(path) || [];
+        this.index = 0;
+        if (this.steps.length > 0) {
+            this.state$.next({ step: this.steps[0], index: 0, total: this.steps.length });
+        }
+    }
+
+    next(): void {
+        this.index++;
+        if (this.index < this.steps.length) {
+            this.state$.next({ step: this.steps[this.index], index: this.index, total: this.steps.length });
+        } else {
+            this.end();
+        }
+    }
+
+    end(): void {
+        this.steps = [];
+        this.index = 0;
+        this.state$.next(null);
+    }
+
+    get tutorial$(): Observable<TutorialState | null> {
+        return this.state$.asObservable();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add reusable tutorial service and overlay component
- trigger tutorials from menu help action
- register sample steps on reservations page
- replace custom popup with PrimeNG popover

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Inlining of fonts failed, status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3136e04bc8328887b5457e062b56f