### PR TITLE
Enable HTML editor for admin email fields

### DIFF
--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -78,7 +78,17 @@ class Res_Pong_Admin_Frontend {
         echo '<table class="form-table">';
         echo '<tr><th><label for="rp-messenger-to">Destinatari</label></th><td><input id="rp-messenger-to" type="text" class="large-text"></td></tr>';
         echo '<tr><th><label for="rp-messenger-subject">Oggetto</label></th><td><input id="rp-messenger-subject" type="text" class="large-text"></td></tr>';
-        echo '<tr><th><label for="rp-messenger-text">Messaggio</label></th><td><textarea id="rp-messenger-text" rows="5" class="large-text" style="max-width:600px;min-height:10rem;"></textarea><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
+        $editor_settings = [
+            'textarea_name' => 'rp-messenger-text',
+            'editor_height' => 200,
+            'media_buttons' => false,
+            'teeny' => true,
+            'quicktags' => true,
+        ];
+        ob_start();
+        wp_editor('', 'rp-messenger-text', $editor_settings);
+        $editor = ob_get_clean();
+        echo '<tr><th><label for="rp-messenger-text">Messaggio</label></th><td><div style="max-width:600px;">' . $editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
         echo '<tr><th></th><td><button type="submit" class="button button-primary">Invia</button></td></tr>';
         echo '</table>';
         echo '</form>';
@@ -137,15 +147,55 @@ class Res_Pong_Admin_Frontend {
         echo '<tr><th><label for="avatar_management">Gestione Avatar</label></th><td><select name="avatar_management" id="avatar_management"><option value="none"' . selected($config['avatar_management'], 'none', false) . '>Nessuna</option><option value="fitet_monitor"' . selected($config['avatar_management'], 'fitet_monitor', false) . '>Fitet Monitor</option><option value="custom"' . selected($config['avatar_management'], 'custom', false) . '>Personalizzata</option></select></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail primo accesso</h2></th></tr>';
         echo '<tr><th><label for="invitation_subject">Oggetto invito</label></th><td><input name="invitation_subject" id="invitation_subject" type="text" class="large-text" style="max-width:600px;" value="' . esc_attr($config['invitation_subject']) . '"></td></tr>';
-        echo '<tr><th><label for="invitation_text">Testo invito</label></th><td><textarea name="invitation_text" id="invitation_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['invitation_text']) . '</textarea><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
+        $invitation_settings = [
+            'textarea_name' => 'invitation_text',
+            'editor_height' => 200,
+            'media_buttons' => false,
+            'teeny' => true,
+            'quicktags' => true,
+        ];
+        ob_start();
+        wp_editor($config['invitation_text'], 'invitation_text', $invitation_settings);
+        $invitation_editor = ob_get_clean();
+        echo '<tr><th><label for="invitation_text">Testo invito</label></th><td><div style="max-width:600px;">' . $invitation_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail reset password</h2></th></tr>';
         echo '<tr><th><label for="reset_password_subject">Oggetto reset password</label></th><td><input name="reset_password_subject" id="reset_password_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['reset_password_subject']) . '"></td></tr>';
-        echo '<tr><th><label for="reset_password_text">Testo reset password</label></th><td><textarea name="reset_password_text" id="reset_password_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['reset_password_text']) . '</textarea><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
+        $reset_settings = [
+            'textarea_name' => 'reset_password_text',
+            'editor_height' => 200,
+            'media_buttons' => false,
+            'teeny' => true,
+            'quicktags' => true,
+        ];
+        ob_start();
+        wp_editor($config['reset_password_text'], 'reset_password_text', $reset_settings);
+        $reset_editor = ob_get_clean();
+        echo '<tr><th><label for="reset_password_text">Testo reset password</label></th><td><div style="max-width:600px;">' . $reset_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail aggiornamento password</h2></th></tr>';
         echo '<tr><th><label for="update_password_subject">Oggetto aggiornamento password</label></th><td><input name="update_password_subject" id="update_password_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['update_password_subject']) . '"></td></tr>';
-        echo '<tr><th><label for="update_password_text">Testo aggiornamento password</label></th><td><textarea name="update_password_text" id="update_password_text" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['update_password_text']) . '</textarea><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
+        $update_settings = [
+            'textarea_name' => 'update_password_text',
+            'editor_height' => 200,
+            'media_buttons' => false,
+            'teeny' => true,
+            'quicktags' => true,
+        ];
+        ob_start();
+        wp_editor($config['update_password_text'], 'update_password_text', $update_settings);
+        $update_editor = ob_get_clean();
+        echo '<tr><th><label for="update_password_text">Testo aggiornamento password</label></th><td><div style="max-width:600px;">' . $update_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">Firma E-mail</h2></th></tr>';
-        echo '<tr><th><label for="mail_signature">Firma Email</label></th><td><textarea name="mail_signature" id="mail_signature" rows="3" class="large-text" style="max-width:600px;min-height:10rem">' . esc_textarea($config['mail_signature']) . '</textarea></td></tr>';
+        $signature_settings = [
+            'textarea_name' => 'mail_signature',
+            'editor_height' => 200,
+            'media_buttons' => false,
+            'teeny' => true,
+            'quicktags' => true,
+        ];
+        ob_start();
+        wp_editor($config['mail_signature'], 'mail_signature', $signature_settings);
+        $signature_editor = ob_get_clean();
+        echo '<tr><th><label for="mail_signature">Firma Email</label></th><td><div style="max-width:600px;">' . $signature_editor . '</div></td></tr>';
         echo '</table>';
         echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva', 'res-pong') . '</button></p>';
         echo '</form>';
@@ -197,14 +247,34 @@ class Res_Pong_Admin_Frontend {
             echo '<div id="rp-invite-wrapper" style="display:none;">';
             echo '<h2>' . esc_html__('Invia Messaggio di Invito', 'res-pong') . '</h2>';
             echo '<p><input type="text" readonly class="large-text" style="max-width: 600px;" id="rp-invite-subject" value="' . esc_attr($config['invitation_subject']) . '"></p>';
-            echo '<p style=" margin-bottom: 0;"><textarea id="rp-invite-text" rows="5" class="large-text" style="max-width:600px;min-height:10rem;">' . esc_textarea($config['invitation_text']) . '</textarea></p>';
+            $invite_settings = [
+                'textarea_name' => 'rp-invite-text',
+                'editor_height' => 200,
+                'media_buttons' => false,
+                'teeny' => true,
+                'quicktags' => true,
+            ];
+            ob_start();
+            wp_editor($config['invitation_text'], 'rp-invite-text', $invite_settings);
+            $invite_editor = ob_get_clean();
+            echo '<div style="margin-bottom: 0; max-width:600px;">' . $invite_editor . '</div>';
             echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p>';
             echo '<p><button type="button" class="button button-primary" id="rp-send-invite">' . esc_html__('Invia', 'res-pong') . '</button></p>';
             echo '</div>';
             echo '<div id="rp-reset-wrapper" style="display:none;">';
             echo '<h2>' . esc_html__('Invia link di reset password', 'res-pong') . '</h2>';
             echo '<p><input type="text" readonly class="large-text" style="max-width: 600px;" id="rp-reset-subject" value="' . esc_attr($config['reset_password_subject']) . '"></p>';
-            echo '<p style=" margin-bottom: 0;"><textarea id="rp-reset-text" rows="5" class="large-text" style="max-width:600px;min-height:10rem;">' . esc_textarea($config['reset_password_text']) . '</textarea></p>';
+            $reset_text_settings = [
+                'textarea_name' => 'rp-reset-text',
+                'editor_height' => 200,
+                'media_buttons' => false,
+                'teeny' => true,
+                'quicktags' => true,
+            ];
+            ob_start();
+            wp_editor($config['reset_password_text'], 'rp-reset-text', $reset_text_settings);
+            $reset_text_editor = ob_get_clean();
+            echo '<div style="margin-bottom: 0; max-width:600px;">' . $reset_text_editor . '</div>';
             echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category</p>';
             echo '<p><button type="button" class="button button-primary" id="rp-send-reset">' . esc_html__('Invia', 'res-pong') . '</button></p>';
             echo '</div>';


### PR DESCRIPTION
## Summary
- replace plain textareas for admin email messages and templates with the WordPress editor

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`

------
https://chatgpt.com/codex/tasks/task_e_68a57f722e488328b8fe49171e25e23a