### PR TITLE
feat: add configuration import export

### DIFF
--- a/includes/admin/class-res-pong-admin-controller.php
+++ b/includes/admin/class-res-pong-admin-controller.php
@@ -209,6 +209,23 @@ class Res_Pong_Admin_Controller {
             },
         ]);
 
+        // Configurations
+        register_rest_route($namespace, '/configurations/export', [
+            'methods' => 'GET',
+            'callback' => [$this->service, 'rest_export_configurations'],
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        ]);
+
+        register_rest_route($namespace, '/configurations/import', [
+            'methods' => 'POST',
+            'callback' => [$this->service, 'rest_import_configurations'],
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            },
+        ]);
+
         register_rest_route($namespace, '/email', [
             'methods' => 'POST',
             'callback' => [$this->service, 'rest_send_email'],

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -149,7 +149,8 @@ class Res_Pong_Admin_Frontend {
         $config = $this->configuration->get_all();
         echo '<div class="wrap rp-wrap">';
         echo '<h1>' . esc_html__('Configurazioni', 'res-pong') . '</h1>';
-        echo '<form method="post">';
+        echo '<p><button type="button" class="button" id="rp-config-import">' . esc_html__('Importa configurazioni', 'res-pong') . '</button> <button type="button" class="button" id="rp-config-export">' . esc_html__('Esporta configurazioni', 'res-pong') . '</button></p>';
+        echo '<form method="post" id="rp-config-form">';
         wp_nonce_field('rp_save_configurations', 'rp_configurations_nonce');
         echo '<table class="form-table">';
         echo '<tr><th><label for="almost_closed_minutes">Minuti alla chiusura</label></th><td><input name="almost_closed_minutes" id="almost_closed_minutes" type="number" value="' . esc_attr($config['almost_closed_minutes']) . '"></td></tr>';

--- a/includes/admin/class-res-pong-admin-service.php
+++ b/includes/admin/class-res-pong-admin-service.php
@@ -438,5 +438,25 @@ class Res_Pong_Admin_Service {
         return new WP_REST_Response(['success' => true], 200);
     }
 
+    public function rest_export_configurations() {
+        $config = $this->configuration->get_all();
+        $json = wp_json_encode($config);
+        nocache_headers();
+        header('Content-Type: application/json; charset=UTF-8');
+        header('Content-Disposition: attachment; filename="configurations.json"');
+        echo $json;
+        exit;
+    }
+
+    public function rest_import_configurations($request) {
+        $params = $request->get_json_params();
+        $config = isset($params['config']) && is_array($params['config']) ? $params['config'] : null;
+        if ($config === null) {
+            return new WP_Error('invalid_data', 'Configurazioni non valide', ['status' => 400]);
+        }
+        $this->configuration->update($config);
+        return new WP_REST_Response(['success' => true], 200);
+    }
+
 
 }


### PR DESCRIPTION
## Summary
- add import and export buttons to configuration page
- expose REST endpoints to import/export configuration JSON
- handle configuration import/export in admin JavaScript

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `php -l includes/admin/class-res-pong-admin-controller.php`
- `php -l includes/admin/class-res-pong-admin-service.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5ada654008328b772e0adef075f5d