### PR TITLE
Add site details and reservation email templates to configuration UI

### DIFF
--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -85,7 +85,7 @@ class Res_Pong_Admin_Frontend {
         ob_start();
         wp_editor('', 'rp-messenger-text', $this->editor_settings);
         $editor = ob_get_clean();
-        echo '<tr><th><label for="rp-messenger-text">Messaggio</label></th><td><div style="max-width:600px;">' . $editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time</p></td></tr>';
+        echo '<tr><th><label for="rp-messenger-text">Messaggio</label></th><td><div style="max-width:600px;">' . $editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
         echo '<tr><th></th><td><button type="submit" class="button button-primary">Invia</button></td></tr>';
         echo '</table>';
         echo '</form>';
@@ -132,15 +132,24 @@ class Res_Pong_Admin_Frontend {
                 'max_active_reservations'  => isset($_POST['max_active_reservations']) ? intval($_POST['max_active_reservations']) : 0,
                 'next_reservation_delay'   => isset($_POST['next_reservation_delay']) ? intval($_POST['next_reservation_delay']) : 0,
                 'default_email_address'    => isset($_POST['default_email_address']) ? sanitize_email($_POST['default_email_address']) : '',
-                'app_url' => isset($_POST['app_url']) ? esc_url_raw($_POST['app_url']) : '',
-                'avatar_management'       => isset($_POST['avatar_management']) ? sanitize_text_field($_POST['avatar_management']) : 'none',
+                'site_name'                => isset($_POST['site_name']) ? sanitize_text_field($_POST['site_name']) : '',
+                'site_url'                 => isset($_POST['site_url']) ? esc_url_raw($_POST['site_url']) : '',
+                'app_name'                 => isset($_POST['app_name']) ? sanitize_text_field($_POST['app_name']) : '',
+                'app_url'                  => isset($_POST['app_url']) ? esc_url_raw($_POST['app_url']) : '',
+                'avatar_management'        => isset($_POST['avatar_management']) ? sanitize_text_field($_POST['avatar_management']) : 'none',
                 'invitation_subject'       => isset($_POST['invitation_subject']) ? sanitize_text_field($_POST['invitation_subject']) : '',
                 'invitation_text'          => isset($_POST['invitation_text']) ? wp_kses_post($_POST['invitation_text']) : '',
                 'reset_password_subject'   => isset($_POST['reset_password_subject']) ? sanitize_text_field($_POST['reset_password_subject']) : '',
                 'reset_password_text'      => isset($_POST['reset_password_text']) ? wp_kses_post($_POST['reset_password_text']) : '',
-                'update_password_subject'   => isset($_POST['update_password_subject']) ? sanitize_text_field($_POST['update_password_subject']) : '',
-                'update_password_text'      => isset($_POST['update_password_text']) ? wp_kses_post($_POST['update_password_text']) : '',
-                'mail_signature'            => isset($_POST['mail_signature']) ? wp_kses_post($_POST['mail_signature']) : '',
+                'update_password_subject'  => isset($_POST['update_password_subject']) ? sanitize_text_field($_POST['update_password_subject']) : '',
+                'update_password_text'     => isset($_POST['update_password_text']) ? wp_kses_post($_POST['update_password_text']) : '',
+                'reservation_confirmed_subject' => isset($_POST['reservation_confirmed_subject']) ? sanitize_text_field($_POST['reservation_confirmed_subject']) : '',
+                'reservation_confirmed_text'    => isset($_POST['reservation_confirmed_text']) ? wp_kses_post($_POST['reservation_confirmed_text']) : '',
+                'reservation_deleted_subject'   => isset($_POST['reservation_deleted_subject']) ? sanitize_text_field($_POST['reservation_deleted_subject']) : '',
+                'reservation_deleted_text'      => isset($_POST['reservation_deleted_text']) ? wp_kses_post($_POST['reservation_deleted_text']) : '',
+                'notify_availability_subject'   => isset($_POST['notify_availability_subject']) ? sanitize_text_field($_POST['notify_availability_subject']) : '',
+                'notify_availability_text'      => isset($_POST['notify_availability_text']) ? wp_kses_post($_POST['notify_availability_text']) : '',
+                'mail_signature'             => isset($_POST['mail_signature']) ? wp_kses_post($_POST['mail_signature']) : '',
 
             ];
             $this->configuration->update($data);
@@ -158,6 +167,9 @@ class Res_Pong_Admin_Frontend {
         echo '<tr><th><label for="max_active_reservations">Max prenotazioni attive</label></th><td><input name="max_active_reservations" id="max_active_reservations" type="number" value="' . esc_attr($config['max_active_reservations']) . '"></td></tr>';
         echo '<tr><th><label for="next_reservation_delay">Ritardo prossima prenotazione</label></th><td><input name="next_reservation_delay" id="next_reservation_delay" type="number" value="' . esc_attr($config['next_reservation_delay']) . '"></td></tr>';
         echo '<tr><th><label for="default_email_address">Email di default</label></th><td><input name="default_email_address" id="default_email_address" type="email" class="regular-text" value="' . esc_attr($config['default_email_address']) . '"></td></tr>';
+        echo '<tr><th><label for="site_name">Nome Sito</label></th><td><input name="site_name" id="site_name" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['site_name']) . '"></td></tr>';
+        echo '<tr><th><label for="site_url">URL Sito</label></th><td><input name="site_url" id="site_url" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['site_url']) . '"></td></tr>';
+        echo '<tr><th><label for="app_name">Nome Applicazione</label></th><td><input name="app_name" id="app_name" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['app_name']) . '"></td></tr>';
         echo '<tr><th><label for="app_url">URL Applicazione</label></th><td><input name="app_url" id="app_url" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['app_url']) . '"></td></tr>';
         echo '<tr><th><label for="avatar_management">Gestione Avatar</label></th><td><select name="avatar_management" id="avatar_management"><option value="none"' . selected($config['avatar_management'], 'none', false) . '>Nessuna</option><option value="fitet_monitor"' . selected($config['avatar_management'], 'fitet_monitor', false) . '>Fitet Monitor</option><option value="custom"' . selected($config['avatar_management'], 'custom', false) . '>Personalizzata</option></select></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail primo accesso</h2></th></tr>';
@@ -166,21 +178,42 @@ class Res_Pong_Admin_Frontend {
         ob_start();
         wp_editor($config['invitation_text'], 'invitation_text', $this->editor_settings);
         $invitation_editor = ob_get_clean();
-        echo '<tr><th><label for="invitation_text">Testo invito</label></th><td><div style="max-width:600px;">' . $invitation_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time</p></td></tr>';
+        echo '<tr><th><label for="invitation_text">Testo invito</label></th><td><div style="max-width:600px;">' . $invitation_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail reset password</h2></th></tr>';
         echo '<tr><th><label for="reset_password_subject">Oggetto reset password</label></th><td><input name="reset_password_subject" id="reset_password_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['reset_password_subject']) . '"></td></tr>';
         $this->editor_settings['textarea_name'] = 'reset_password_text';
         ob_start();
         wp_editor($config['reset_password_text'], 'reset_password_text', $this->editor_settings);
         $reset_editor = ob_get_clean();
-        echo '<tr><th><label for="reset_password_text">Testo reset password</label></th><td><div style="max-width:600px;">' . $reset_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time</p></td></tr>';
+        echo '<tr><th><label for="reset_password_text">Testo reset password</label></th><td><div style="max-width:600px;">' . $reset_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail aggiornamento password</h2></th></tr>';
         echo '<tr><th><label for="update_password_subject">Oggetto aggiornamento password</label></th><td><input name="update_password_subject" id="update_password_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['update_password_subject']) . '"></td></tr>';
         $this->editor_settings['textarea_name'] = 'update_password_text';
         ob_start();
         wp_editor($config['update_password_text'], 'update_password_text', $this->editor_settings);
         $update_editor = ob_get_clean();
-        echo '<tr><th><label for="update_password_text">Testo aggiornamento password</label></th><td><div style="max-width:600px;">' . $update_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time</p></td></tr>';
+        echo '<tr><th><label for="update_password_text">Testo aggiornamento password</label></th><td><div style="max-width:600px;">' . $update_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
+        echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail prenotazione confermata</h2></th></tr>';
+        echo '<tr><th><label for="reservation_confirmed_subject">Oggetto prenotazione confermata</label></th><td><input name="reservation_confirmed_subject" id="reservation_confirmed_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['reservation_confirmed_subject']) . '"></td></tr>';
+        $this->editor_settings['textarea_name'] = 'reservation_confirmed_text';
+        ob_start();
+        wp_editor($config['reservation_confirmed_text'], 'reservation_confirmed_text', $this->editor_settings);
+        $reservation_confirmed_editor = ob_get_clean();
+        echo '<tr><th><label for="reservation_confirmed_text">Testo prenotazione confermata</label></th><td><div style="max-width:600px;">' . $reservation_confirmed_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
+        echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail prenotazione cancellata</h2></th></tr>';
+        echo '<tr><th><label for="reservation_deleted_subject">Oggetto prenotazione cancellata</label></th><td><input name="reservation_deleted_subject" id="reservation_deleted_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['reservation_deleted_subject']) . '"></td></tr>';
+        $this->editor_settings['textarea_name'] = 'reservation_deleted_text';
+        ob_start();
+        wp_editor($config['reservation_deleted_text'], 'reservation_deleted_text', $this->editor_settings);
+        $reservation_deleted_editor = ob_get_clean();
+        echo '<tr><th><label for="reservation_deleted_text">Testo prenotazione cancellata</label></th><td><div style="max-width:600px;">' . $reservation_deleted_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
+        echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail notifica disponibilità</h2></th></tr>';
+        echo '<tr><th><label for="notify_availability_subject">Oggetto notifica disponibilità</label></th><td><input name="notify_availability_subject" id="notify_availability_subject" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['notify_availability_subject']) . '"></td></tr>';
+        $this->editor_settings['textarea_name'] = 'notify_availability_text';
+        ob_start();
+        wp_editor($config['notify_availability_text'], 'notify_availability_text', $this->editor_settings);
+        $notify_availability_editor = ob_get_clean();
+        echo '<tr><th><label for="notify_availability_text">Testo notifica disponibilità</label></th><td><div style="max-width:600px;">' . $notify_availability_editor . '</div><p style="font-size:12px;color:#555;margin-top:0;max-width:600px;">Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">Firma E-mail</h2></th></tr>';
         $this->editor_settings['textarea_name'] = 'mail_signature';
         ob_start();
@@ -256,7 +289,7 @@ class Res_Pong_Admin_Frontend {
             wp_editor($config['invitation_text'], 'rp-invite-text', $this->editor_settings);
             $invite_editor = ob_get_clean();
             echo '<div style="margin-bottom: 0; max-width:600px;">' . $invite_editor . '</div>';
-            echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time</p>';
+            echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di invito sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p>';
             echo '<p><button type="button" class="button button-primary" id="rp-send-invite">' . esc_html__('Invia', 'res-pong') . '</button></p>';
             echo '</div>';
             echo '<div id="rp-reset-wrapper" style="display:none;">';
@@ -267,7 +300,7 @@ class Res_Pong_Admin_Frontend {
             wp_editor($config['reset_password_text'], 'rp-reset-text', $this->editor_settings);
             $reset_text_editor = ob_get_clean();
             echo '<div style="margin-bottom: 0; max-width:600px;">' . $reset_text_editor . '</div>';
-            echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time</p>';
+            echo '<p style="font-size:12px;color:#555; margin-top: 0; max-width:600px;">Il link di reset password sarà aggiunto in coda all\'email. Usa i seguenti placeholder per personalizzare l\'email: #email, #username, #last_name, #first_name, #category, #now_date_and_time, #now_date_only, #app_url, #app_name, #site_url, #site_name</p>';
             echo '<p><button type="button" class="button button-primary" id="rp-send-reset">' . esc_html__('Invia', 'res-pong') . '</button></p>';
             echo '</div>';
             $default_timeout = date('Y-m-d\\T00:00:00', strtotime('+7 days'));


### PR DESCRIPTION
## Summary
- Allow editing site name, site URL, and app name in configuration
- Add email templates for reservation confirmed/cancelled and availability notifications
- Expand placeholder hints across email editors with more tokens

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`

------
https://chatgpt.com/codex/tasks/task_e_68a5c24c23d083288d25dc7317c56d29