### PR TITLE
feat: add user select for event reservations

### DIFF
--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -349,6 +349,7 @@ class Res_Pong_Admin_Frontend {
         if ($editing) {
             echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=res-pong-email&event_id=' . $id)) . '">Contatta i partecipanti</a></p>';
             echo '<h2>' . esc_html__('Prenotazioni evento', 'res-pong') . '</h2>';
+            echo '<div id="res-pong-event-reservations-message"></div>';
             echo '<table id="res-pong-event-reservations" class="display" data-event="' . esc_attr($id) . '"></table>';
         }
         $this->render_progress_overlay();


### PR DESCRIPTION
## Summary
- allow admins to add event reservations directly from event detail page via user select
- show success or error notices and refresh reservations table without leaving page

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ea95f1f4832888906c14f75febf7