### PR TITLE
feat: enhance user reservation adding

### DIFF
--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -314,6 +314,7 @@ class Res_Pong_Admin_Frontend {
             echo '<p class="submit"><button type="submit" class="button button-primary">' . esc_html__('Salva timeout', 'res-pong') . '</button> <button type="button" class="button" id="rp-remove-timeout">' . esc_html__('Rimuovi timeout', 'res-pong') . '</button></p>';
             echo '</form>';
             echo '<h2>' . esc_html__('Prenotazioni utente', 'res-pong') . '</h2>';
+            echo '<div id="res-pong-user-reservations-message"></div>';
             echo '<table id="res-pong-user-reservations" class="display" data-user="' . esc_attr($id) . '"></table>';
         }
         $this->render_progress_overlay();


### PR DESCRIPTION
## Summary
- allow selecting future events before adding user reservations
- show success or error messages when adding user reservations

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `node --check assets/js/res-pong-admin.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6efd6e1dc8328800cbc1d2cf8c62e