### PR TITLE
Add dedicated event reservations page

### DIFF
--- a/assets/css/res-pong-admin.css
+++ b/assets/css/res-pong-admin.css
@@ -26,6 +26,11 @@
 
 }
 
+.rp-heading-link {
+    float: right;
+    text-decoration: none;
+}
+
 .rp-bulk {
     display: flex;
     align-items: center;

--- a/assets/js/res-pong-admin.js
+++ b/assets/js/res-pong-admin.js
@@ -1223,6 +1223,18 @@
             var eid = er.data('event');
             var erTable = initTable(er, 'reservations', function(){ return restUrl('reservations', 'event_id=' + eid + '&active_only=0'); }, { columns: columns.event_reservations, addParams: 'event_id=' + eid, noCsv: true, filterFuture: false, selectable: false, order: [[0, 'asc']] });
             initEventReservationAdder(erTable, eid);
+            var title = $('#rp-event-reservations-title');
+            if(title.length){
+                $.ajax({
+                    url: restUrl('events/' + eid),
+                    method: 'GET',
+                    beforeSend: function(xhr){ xhr.setRequestHeader('X-WP-Nonce', rp_admin.nonce); },
+                    success: function(ev){
+                        var dt = ev.start_datetime ? ev.start_datetime.substring(0, 16) : '';
+                        title.text('Prenotazioni ' + ev.name + ' - ' + dt);
+                    }
+                });
+            }
         }
         var en = $('#res-pong-event-notifications');
         if(en.length){

--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -30,6 +30,7 @@ class Res_Pong_Admin_Frontend {
         add_submenu_page('res-pong-users', 'Email', 'Email', 'manage_options', 'res-pong-email', [ $this, 'render_email_page' ]);
         add_submenu_page(null, 'Dettaglio Utente', 'Dettaglio Utente', 'manage_options', 'res-pong-user-detail', [ $this, 'render_user_detail' ]);
         add_submenu_page(null, 'Dettaglio Evento', 'Dettaglio Evento', 'manage_options', 'res-pong-event-detail', [ $this, 'render_event_detail' ]);
+        add_submenu_page(null, 'Prenotazioni Evento', 'Prenotazioni Evento', 'manage_options', 'res-pong-event-reservations', [ $this, 'render_event_reservations_page' ]);
         add_submenu_page(null, 'Dettaglio Prenotazione', 'Dettaglio Prenotazione', 'manage_options', 'res-pong-reservation-detail', [ $this, 'render_reservation_detail' ]);
     }
 
@@ -353,13 +354,23 @@ class Res_Pong_Admin_Frontend {
         echo '</p></form>';
         if ($editing) {
             echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=res-pong-email&event_id=' . $id)) . '">Contatta i partecipanti</a></p>';
-            echo '<h2>' . esc_html__('Prenotazioni evento', 'res-pong') . '</h2>';
+            echo '<h2><a href="' . esc_url(admin_url('admin.php?page=res-pong-event-reservations&id=' . $id)) . '" class="dashicons dashicons-external rp-heading-link"></a>' . esc_html__('Prenotazioni evento', 'res-pong') . '</h2>';
             echo '<div id="res-pong-event-reservations-message"></div>';
             echo '<table id="res-pong-event-reservations" class="display" data-event="' . esc_attr($id) . '"></table>';
             echo '<h2>' . esc_html__('Richiesta Notifiche', 'res-pong') . '</h2>';
             echo '<div id="res-pong-event-notifications-message"></div>';
             echo '<table id="res-pong-event-notifications" class="display" data-event="' . esc_attr($id) . '"></table>';
         }
+        $this->render_progress_overlay();
+        echo '</div>';
+    }
+
+    public function render_event_reservations_page() {
+        $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+        echo '<div class="wrap rp-wrap">';
+        echo '<h1 id="rp-event-reservations-title">' . esc_html__('Prenotazioni evento', 'res-pong') . '</h1>';
+        echo '<div id="res-pong-event-reservations-message"></div>';
+        echo '<table id="res-pong-event-reservations" class="display" data-event="' . esc_attr($id) . '"></table>';
         $this->render_progress_overlay();
         echo '</div>';
     }


### PR DESCRIPTION
## Summary
- add hidden admin page to view reservations for a single event
- link event detail's reservation header to the new page
- style header link and populate page title with event name and date

## Testing
- `php -l includes/admin/class-res-pong-admin-frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_68a726c2f53c8328bfbbab0b7e0b606d