### PR TITLE
Add login disclaimer config and endpoint

### DIFF
--- a/includes/admin/class-res-pong-admin-frontend.php
+++ b/includes/admin/class-res-pong-admin-frontend.php
@@ -139,6 +139,7 @@ class Res_Pong_Admin_Frontend {
                 'site_url'                      => isset($_POST['site_url']) ? esc_url_raw($_POST['site_url']) : '',
                 'app_name'                      => isset($_POST['app_name']) ? sanitize_text_field($_POST['app_name']) : '',
                 'app_url'                       => isset($_POST['app_url']) ? esc_url_raw($_POST['app_url']) : '',
+                'login_disclaimer'              => isset($_POST['login_disclaimer']) ? wp_unslash(wp_kses_post($_POST['login_disclaimer'])) : '',
                 'avatar_management'             => isset($_POST['avatar_management']) ? sanitize_text_field($_POST['avatar_management']) : 'none',
                 'invitation_subject'            => isset($_POST['invitation_subject']) ? sanitize_text_field($_POST['invitation_subject']) : '',
                 'invitation_text'               => isset($_POST['invitation_text']) ? wp_unslash(wp_kses_post($_POST['invitation_text'])) : '',
@@ -176,6 +177,11 @@ class Res_Pong_Admin_Frontend {
         echo '<tr><th><label for="site_url">URL Sito</label></th><td><input name="site_url" id="site_url" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['site_url']) . '"></td></tr>';
         echo '<tr><th><label for="app_name">Nome Applicazione</label></th><td><input name="app_name" id="app_name" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['app_name']) . '"></td></tr>';
         echo '<tr><th><label for="app_url">URL Applicazione</label></th><td><input name="app_url" id="app_url" type="text" style="max-width:600px;" class="large-text" value="' . esc_attr($config['app_url']) . '"></td></tr>';
+        $this->editor_settings['textarea_name'] = 'login_disclaimer';
+        ob_start();
+        wp_editor($config['login_disclaimer'], 'login_disclaimer', $this->editor_settings);
+        $login_disclaimer_editor = ob_get_clean();
+        echo '<tr><th><label for="login_disclaimer">Disclaimer login</label></th><td><div style="max-width:600px;">' . $login_disclaimer_editor . '</div></td></tr>';
         echo '<tr><th><label for="avatar_management">Gestione Avatar</label></th><td><select name="avatar_management" id="avatar_management"><option value="none"' . selected($config['avatar_management'], 'none', false) . '>Nessuna</option><option value="fitet_monitor"' . selected($config['avatar_management'], 'fitet_monitor', false) . '>Fitet Monitor</option><option value="custom"' . selected($config['avatar_management'], 'custom', false) . '>Personalizzata</option></select></td></tr>';
         echo '<tr><th colspan="2"><h2 style="margin: 0">E-mail primo accesso</h2></th></tr>';
         echo '<tr><th><label for="invitation_subject">Oggetto invito</label></th><td><input name="invitation_subject" id="invitation_subject" type="text" class="large-text" style="max-width:600px;" value="' . esc_attr($config['invitation_subject']) . '"></td></tr>';

--- a/includes/common/class-res-pong-configuration.php
+++ b/includes/common/class-res-pong-configuration.php
@@ -21,6 +21,8 @@ class Res_Pong_Configuration {
         'app_url' => RES_PONG_CONFIGURATION_SITE_URL . "/prenotazioni",
         'app_name' => "Portale Prenotazioni",
 
+        'login_disclaimer' => '',
+
         'invitation_subject' => "Effettua il tuo primo accesso - #app_name",
         'invitation_text' => "Ciao #first_name,\n\nStai per entrare nel #app_name!\n\nPer per completare la configurazione del tuo profilo, clicca su questo link:\n\n<strong><a href=\"#link\">Completa configurazione</a></strong>\n\n&nbsp;\n\nSe il collegamento non dovesse funzionare, copia e incolla il seguente indirizzo nel tuo browser:\n#link\n\n&nbsp;",
       

--- a/includes/user/class-res-pong-user-controller.php
+++ b/includes/user/class-res-pong-user-controller.php
@@ -126,6 +126,12 @@ class Res_Pong_User_Controller {
             'permission_callback' => '__return_true'
         ]);
 
+        register_rest_route('res-pong/v1', '/login-disclaimer', [
+            'methods' => 'GET',
+            'callback' => [$res_pong_admin, 'get_login_disclaimer'],
+            'permission_callback' => '__return_true'
+        ]);
+
         register_rest_route('res-pong/v1', '/configurations', [
             'methods' => 'GET',
             'callback' => [$res_pong_admin, 'get_public_configurations'],

--- a/includes/user/class-res-pong-user-service.php
+++ b/includes/user/class-res-pong-user-service.php
@@ -208,6 +208,11 @@ class Res_Pong_User_Service {
         return new \WP_REST_Response(['success' => true], 200);
     }
 
+    public function get_login_disclaimer() {
+        $disclaimer = $this->configuration->get('login_disclaimer');
+        return rest_ensure_response($disclaimer);
+    }
+
     public function get_public_configurations() {
         $configurations = $this->configuration->get_public_configurations();
         return rest_ensure_response($configurations);


### PR DESCRIPTION
## Summary
- allow admins to configure a login disclaimer HTML block
- expose login disclaimer via public REST endpoint

## Testing
- `php -l includes/common/class-res-pong-configuration.php`
- `php -l includes/admin/class-res-pong-admin-frontend.php`
- `php -l includes/user/class-res-pong-user-service.php`
- `php -l includes/user/class-res-pong-user-controller.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6939c71ac8328824039a426ea0ba2